### PR TITLE
Scroll view in screening info pop-up

### DIFF
--- a/PresentScreenings/Controllers/DownloadFilmInfoController.cs
+++ b/PresentScreenings/Controllers/DownloadFilmInfoController.cs
@@ -113,21 +113,21 @@ namespace PresentScreenings.TableView
             // Create the selected films count label.
             yCurr -= _labelHeight;
             var selectedCountRect = new CGRect(_xMargin, yCurr, _contentWidth, _labelHeight);
-            var selectedCountLabel = ControlsFactory.CreateStandardLabel(selectedCountRect);
+            var selectedCountLabel = ControlsFactory.NewStandardLabel(selectedCountRect);
             selectedCountLabel.StringValue = $"Selected films: {_films.Count}";
             View.AddSubview(selectedCountLabel);
 
             // Create the films without info count label.
             yCurr -= _yBetweenLabels + _labelHeight;
             var withoutInfoRect = new CGRect(_xMargin, yCurr, _contentWidth, _labelHeight);
-            var withoutInfoLabel = ControlsFactory.CreateStandardLabel(withoutInfoRect);
+            var withoutInfoLabel = ControlsFactory.NewStandardLabel(withoutInfoRect);
             withoutInfoLabel.StringValue = $"Without info: {_filmsWithoutInfo.Count}";
             View.AddSubview(withoutInfoLabel);
 
             //Create the progress label.
             yCurr -= _yBetweenLabels + _labelHeight;
             var progressRect = new CGRect(_xMargin, yCurr, _contentWidth, _labelHeight);
-            _progressLabel = ControlsFactory.CreateStandardLabel(progressRect);
+            _progressLabel = ControlsFactory.NewStandardLabel(progressRect);
             SetProgressLabelStringValue();
             View.AddSubview(_progressLabel);
         }
@@ -153,7 +153,7 @@ namespace PresentScreenings.TableView
             _activityField.SetFrameSize(fit);
 
             var rect = new CGRect(_xMargin, yCurr, _contentWidth, height);
-            _activityScrollView = ControlsFactory.CreateStandardScrollView(rect, _activityField);
+            _activityScrollView = ControlsFactory.NewStandardScrollView(rect, _activityField);
             View.AddSubview(_activityScrollView);
         }
 
@@ -175,7 +175,7 @@ namespace PresentScreenings.TableView
 
             // Create the Start button.
             var startButtonRect = new CGRect(xCurr, yCurr, _buttonWidth + 10, _buttonHeight);
-            _startButton = ControlsFactory.CreateStandardButton(startButtonRect);
+            _startButton = ControlsFactory.NewStandardButton(startButtonRect);
             _startButton.Title = $"Visit {visitCount} sites";
             _startButton.LineBreakMode = NSLineBreakMode.ByWordWrapping;
             _startButton.KeyEquivalent = ControlsFactory.EnterKey;
@@ -186,7 +186,7 @@ namespace PresentScreenings.TableView
 
             // Create the All Films button.
             var allFilmsButtonRect = new CGRect(xCurr, yCurr, _buttonWidth, _buttonHeight);
-            _allFilmsButton = ControlsFactory.CreateStandardButton(allFilmsButtonRect);
+            _allFilmsButton = ControlsFactory.NewStandardButton(allFilmsButtonRect);
             _allFilmsButton.Title = "All films";
             _allFilmsButton.Enabled = false;
             _allFilmsButton.Action = new ObjCRuntime.Selector("VisitAllFilms:");
@@ -195,7 +195,7 @@ namespace PresentScreenings.TableView
 
             // Create the Cancel button.
             var cancelButtonRect = new CGRect(xCurr, yCurr, _buttonWidth, _buttonHeight);
-            _cancelButton = ControlsFactory.CreateCancelButton(cancelButtonRect);
+            _cancelButton = ControlsFactory.NewCancelButton(cancelButtonRect);
             _cancelButton.Title = "Close";
             _cancelButton.Action = new ObjCRuntime.Selector("CancelDownloadFilmInfo:");
             View.AddSubview(_cancelButton);

--- a/PresentScreenings/Controllers/FilmInfoDialogController.cs
+++ b/PresentScreenings/Controllers/FilmInfoDialogController.cs
@@ -119,7 +119,7 @@ namespace PresentScreenings.TableView
         {
             yCurr -= _labelHeight;
             var rect = new CGRect(_xMargin, yCurr, _contentWidth, _labelHeight);
-            var filmTitleLabel = ControlsFactory.CreateStandardLabel(rect);
+            var filmTitleLabel = ControlsFactory.NewStandardLabel(rect);
             filmTitleLabel.StringValue = _film.Title;
             filmTitleLabel.Font = NSFont.BoldSystemFontOfSize(NSFont.SystemFontSize);
             View.AddSubview(filmTitleLabel);
@@ -139,7 +139,7 @@ namespace PresentScreenings.TableView
             var scrollViewHeight = yCurr - _yBetweenViews - _buttonHeight - _yMargin;
             yCurr -= (float)scrollViewHeight;
             var scrollViewFrame = new CGRect(_xMargin, yCurr, _contentWidth, scrollViewHeight);
-            var scrollView = ControlsFactory.CreateStandardScrollView(scrollViewFrame, screeningsView);
+            var scrollView = ControlsFactory.NewStandardScrollView(scrollViewFrame, screeningsView);
             View.AddSubview(scrollView);
 
             // Display the screenings.
@@ -198,7 +198,7 @@ namespace PresentScreenings.TableView
 
             yCurr -= summaryBoxHeight;
             var rect = new CGRect(_xMargin, yCurr, _contentWidth, summaryBoxHeight);
-            _summaryScrollView = ControlsFactory.CreateStandardScrollView(rect, _summaryField);
+            _summaryScrollView = ControlsFactory.NewStandardScrollView(rect, _summaryField);
             _summaryScrollView.ContentView.ScrollToPoint(new CGPoint(0, 0));
             View.AddSubview(_summaryScrollView);
         }
@@ -207,8 +207,8 @@ namespace PresentScreenings.TableView
         {
             yCurr -= _buttonHeight;
             var cancelButtonRect = new CGRect(_xMargin, yCurr, _buttonWidth, _buttonHeight);
-            _cancelButton = ControlsFactory.CreateCancelButton(cancelButtonRect);
-            _cancelButton.Title = "Done";
+            _cancelButton = ControlsFactory.NewCancelButton(cancelButtonRect);
+            _cancelButton.Title = "Close";
             _cancelButton.Action = new ObjCRuntime.Selector("CancelGotoScreening:");
             View.AddSubview(_cancelButton);
         }

--- a/PresentScreenings/Controllers/FilmInfoDialogController.cs
+++ b/PresentScreenings/Controllers/FilmInfoDialogController.cs
@@ -43,6 +43,7 @@ namespace PresentScreenings.TableView
         NSScrollView _summaryScrollView;
         NSButton _linkButton;
         NSButton _cancelButton;
+        FilmScreeningControl _currentScreeningControl;
         #endregion
 
         #region Application Access
@@ -50,7 +51,7 @@ namespace PresentScreenings.TableView
         #endregion
 
         #region Properties
-        public GoToScreeningDialog Presentor;
+        public static GoToScreeningDialog Presentor;
         public bool ShowScreenings = true;
         #endregion
 
@@ -142,33 +143,7 @@ namespace PresentScreenings.TableView
             View.AddSubview(scrollView);
 
             // Display the screenings.
-            DisplayScreeningControls(screenings, screeningsView);
-        }
-
-        void DisplayScreeningControls(List<Screening> screenings, NSView screeningsView)
-        {
-            var yScreening = screeningsView.Frame.Height;
-            foreach (var screening in screenings)
-            {
-                float xScreening = 0;
-                yScreening -= _labelHeight;
-
-                // Create the screening info button.
-                var buttonRect = new CGRect(xScreening, yScreening, 20, _labelHeight);
-                var infoButton = new FilmScreeningControl(buttonRect, screening);
-                infoButton.ScreeningInfoAsked += (sender, e) => GoToScreening(screening);
-                screeningsView.AddSubview(infoButton);
-                xScreening += 22;
-
-                // Create the screening label.
-                var labelRect = new CGRect(xScreening, yScreening, _contentWidth - xScreening, _labelHeight);
-                var screeningLabel = ControlsFactory.CreateStandardLabel(labelRect);
-                screeningLabel.StringValue = screening.ToFilmScreeningLabelString();
-                ColorView.SetScreeningColor(screening, screeningLabel);
-                screeningsView.AddSubview(screeningLabel);
-
-                yScreening -= _yBetweenLabels;
-            }
+            GoToScreeningDialog.DisplayScreeningControls(screenings, screeningsView, GoToScreening, ref _currentScreeningControl);
         }
 
         void CreateFilmArticleLink(ref float yCurr)
@@ -319,7 +294,7 @@ namespace PresentScreenings.TableView
             }
         }
 
-        void GoToScreening(Screening screening)
+        private static void GoToScreening(Screening screening)
         {
             Presentor.GoToScreening(screening);
         }

--- a/PresentScreenings/Controllers/FilmRatingDialogController.cs
+++ b/PresentScreenings/Controllers/FilmRatingDialogController.cs
@@ -117,7 +117,7 @@ namespace PresentScreenings.TableView
                     break;
                 case "GoToScreeningSegue":
                     var goToScreeningPopOver = segue.DestinationController as FilmInfoDialogController;
-                    goToScreeningPopOver.Presentor = this;
+                    FilmInfoDialogController.Presentor = this;
                     break;
                 case "DownloadFilmInfoSegue":
                     var downloadFilmInfoOpen = segue.DestinationController as DownloadFilmInfoController;

--- a/PresentScreenings/Controllers/GoToScreeningDialog.cs
+++ b/PresentScreenings/Controllers/GoToScreeningDialog.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using AppKit;
+using CoreGraphics;
 
 namespace PresentScreenings.TableView
 {
@@ -10,10 +12,80 @@ namespace PresentScreenings.TableView
 
     public abstract class GoToScreeningDialog : NSViewController
     {
+        #region Constants
+        const float _yBetweenLabels = ControlsFactory.VerticalPixelsBetweenLabels;
+        const float _xBetweenLabels = _yBetweenLabels;
+        const float _labelHeight = ControlsFactory.StandardLabelHeight;
+        const float _buttonWidth = _labelHeight;
+        #endregion
+
+        #region Application Access
+        static AppDelegate _app => (AppDelegate)NSApplication.SharedApplication.Delegate;
+        #endregion
+
+        #region Private Members
+        static Dictionary<Screening, NSTextField> _labelByfilmScreening;
+        #endregion
+
+        #region Constructors
         public GoToScreeningDialog(IntPtr handle) : base(handle)
         {
         }
+        #endregion
 
+        #region Virtual Methods
+        public static void DisplayScreeningControls(List<Screening> screenings, NSView screeningsView,
+            GoToScreeningDelegate goToScreening, ref FilmScreeningControl currentScreeningControl)
+        {
+            _labelByfilmScreening = new Dictionary<Screening, NSTextField> { };
+            var yScreening = screeningsView.Frame.Height;
+            var contentWidth = screeningsView.Frame.Width;
+            foreach (var screening in screenings)
+            {
+                float xScreening = 0;
+                yScreening -= _labelHeight;
+
+                // Create the screening info button.
+                var buttonRect = new CGRect(xScreening, yScreening, _buttonWidth, _labelHeight);
+                var infoButton = new FilmScreeningControl(buttonRect, screening);
+                infoButton.ReDraw();
+                infoButton.ScreeningInfoAsked += (sender, e) => goToScreening(screening);
+                if (screening == _app.Controller.CurrentScreening)
+                {
+                    currentScreeningControl = infoButton;
+                    currentScreeningControl.Selected = true;
+                }
+                screeningsView.AddSubview(infoButton);
+                xScreening += _buttonWidth + _xBetweenLabels;
+
+                // Create the screening label.
+                var labelRect = new CGRect(xScreening, yScreening, contentWidth - xScreening, _labelHeight);
+                var screeningLabel = ControlsFactory.CreateStandardLabel(labelRect);
+                screeningLabel.StringValue = screening.ToFilmScreeningLabelString();
+                ColorView.SetScreeningColor(screening, screeningLabel);
+                screeningsView.AddSubview(screeningLabel);
+                _labelByfilmScreening.Add(screening, screeningLabel);
+
+                yScreening -= _yBetweenLabels;
+            }
+        }
+
+        static public void UpdateScreeningControls()
+        {
+            foreach (var screening in _labelByfilmScreening.Keys)
+            {
+                ColorView.SetScreeningColor(screening, _labelByfilmScreening[screening]);
+                _labelByfilmScreening[screening].StringValue = screening.ToFilmScreeningLabelString();
+            }
+        }
+        #endregion
+
+        #region Abstract Methods
         public abstract void GoToScreening(Screening screening);
+        #endregion
+
+        #region Delagates
+        public delegate void GoToScreeningDelegate(Screening screening);
+        #endregion
     }
 }

--- a/PresentScreenings/Controllers/GoToScreeningDialog.cs
+++ b/PresentScreenings/Controllers/GoToScreeningDialog.cs
@@ -37,16 +37,23 @@ namespace PresentScreenings.TableView
         public static void DisplayScreeningControls(List<Screening> screenings, NSView screeningsView,
             GoToScreeningDelegate goToScreening, ref FilmScreeningControl currentScreeningControl)
         {
+            // Initialize the dictionary to find labels by screening.
             _labelByfilmScreening = new Dictionary<Screening, NSTextField> { };
+
+            // Initialize dimensions.
+            var xLabel = _buttonWidth + _xBetweenLabels;
             var yScreening = screeningsView.Frame.Height;
             var contentWidth = screeningsView.Frame.Width;
+            var buttonRect = new CGRect(0, yScreening, _buttonWidth, _labelHeight);
+            var labelRect = new CGRect(xLabel, yScreening, contentWidth - xLabel, _labelHeight);
+
             foreach (var screening in screenings)
             {
-                float xScreening = 0;
+                // Update the vertical position.
                 yScreening -= _labelHeight;
 
                 // Create the screening info button.
-                var buttonRect = new CGRect(xScreening, yScreening, _buttonWidth, _labelHeight);
+                buttonRect.Y = yScreening;
                 var infoButton = new FilmScreeningControl(buttonRect, screening);
                 infoButton.ReDraw();
                 infoButton.ScreeningInfoAsked += (sender, e) => goToScreening(screening);
@@ -56,17 +63,26 @@ namespace PresentScreenings.TableView
                     currentScreeningControl.Selected = true;
                 }
                 screeningsView.AddSubview(infoButton);
-                xScreening += _buttonWidth + _xBetweenLabels;
 
                 // Create the screening label.
-                var labelRect = new CGRect(xScreening, yScreening, contentWidth - xScreening, _labelHeight);
-                var screeningLabel = ControlsFactory.CreateStandardLabel(labelRect);
+                labelRect.Y = yScreening;
+                var screeningLabel = ControlsFactory.NewStandardLabel(labelRect);
                 screeningLabel.StringValue = screening.ToFilmScreeningLabelString();
                 ColorView.SetScreeningColor(screening, screeningLabel);
                 screeningsView.AddSubview(screeningLabel);
+
+                // Link the label to the screening.
                 _labelByfilmScreening.Add(screening, screeningLabel);
 
                 yScreening -= _yBetweenLabels;
+            }
+        }
+
+        static public void ScrollScreeningToVisible(Screening screening, NSScrollView scrollView)
+        {
+            if (_labelByfilmScreening.ContainsKey(screening))
+            {
+                scrollView.ContentView.ScrollRectToVisible(_labelByfilmScreening[screening].Frame);
             }
         }
 

--- a/PresentScreenings/Controllers/ScreeningDialogController.cs
+++ b/PresentScreenings/Controllers/ScreeningDialogController.cs
@@ -183,11 +183,15 @@ namespace PresentScreenings.TableView
             var scrollViewHeight = _yCurr - _yBetweenViews - _buttonHeight - _yMargin;
             _yCurr -= scrollViewHeight;
             var scrollViewFrame = new CGRect(_xMargin, _yCurr, contentWidth, scrollViewHeight);
-            var scrollView = ControlsFactory.CreateStandardScrollView(scrollViewFrame, screeningsView);
+            var scrollView = ControlsFactory.NewStandardScrollView(scrollViewFrame, screeningsView);
             View.AddSubview(scrollView);
 
             // Display the screenings.
             GoToScreeningDialog.DisplayScreeningControls(screenings, screeningsView, GoToScreening, ref _screeningInfoControl);
+
+            // Scroll to the selected screening.
+            GoToScreeningDialog.ScrollScreeningToVisible(CurrentScreening, scrollView);
+
         }
 
         void UpdateAttendances()

--- a/PresentScreenings/Controllers/UncombineTitlesSheetController.cs
+++ b/PresentScreenings/Controllers/UncombineTitlesSheetController.cs
@@ -169,7 +169,7 @@ namespace PresentScreenings.TableView
 
             _screeningsView = new NSView(_screeningsFrame);
 
-            var scrollView = ControlsFactory.CreateStandardScrollView(_scrollerFrame, _screeningsView);
+            var scrollView = ControlsFactory.NewStandardScrollView(_scrollerFrame, _screeningsView);
             View.AddSubview(scrollView);
         }
 
@@ -189,7 +189,7 @@ namespace PresentScreenings.TableView
         void CreateCancelButton()
         {
             CGRect cancelButtonRect = new CGRect(_xMargin, _yMargin, _cancelButtonWidth, _buttonHeight);
-            NSButton cancelButton = ControlsFactory.CreateCancelButton(cancelButtonRect);
+            NSButton cancelButton = ControlsFactory.NewCancelButton(cancelButtonRect);
             cancelButton.Action = new ObjCRuntime.Selector("CancelUncombine:");
             View.AddSubview(cancelButton);
         }

--- a/PresentScreenings/ControlsFactory.cs
+++ b/PresentScreenings/ControlsFactory.cs
@@ -30,7 +30,7 @@ namespace PresentScreenings.TableView
         #endregion
 
         #region Public Methods
-        public static NSTextField CreateStandardLabel(CGRect frame)
+        public static NSTextField NewStandardLabel(CGRect frame)
         {
             var label = new NSTextField(frame)
             {
@@ -42,7 +42,7 @@ namespace PresentScreenings.TableView
             return label;
         }
 
-        public static NSButton CreateStandardButton(CGRect frame)
+        public static NSButton NewStandardButton(CGRect frame)
         {
             var button = new NSButton(frame)
             {
@@ -53,9 +53,9 @@ namespace PresentScreenings.TableView
             return button;
         }
 
-        public static NSButton CreateCancelButton(CGRect frame)
+        public static NSButton NewCancelButton(CGRect frame)
         {
-            var cancelButton = ControlsFactory.CreateStandardButton(frame);
+            var cancelButton = ControlsFactory.NewStandardButton(frame);
             cancelButton.Title = "Cancel";
             cancelButton.KeyEquivalent = EscapeKey;
             return cancelButton;
@@ -71,7 +71,7 @@ namespace PresentScreenings.TableView
             return comboBox;
         }
 
-        public static NSScrollView CreateStandardScrollView(CGRect frame, NSView documentView)
+        public static NSScrollView NewStandardScrollView(CGRect frame, NSView documentView)
         {
             var scrollView = new NSScrollView(frame);
             scrollView.BackgroundColor = NSColor.WindowBackground;

--- a/PresentScreenings/ControlsFactory.cs
+++ b/PresentScreenings/ControlsFactory.cs
@@ -1,5 +1,8 @@
-﻿using AppKit;
+﻿using System;
+using System.Linq;
+using AppKit;
 using CoreGraphics;
+using Foundation;
 
 namespace PresentScreenings.TableView
 {
@@ -10,6 +13,7 @@ namespace PresentScreenings.TableView
         public const float SmallVerticalMargin = 8;
         public const float BigVerticalMargin = 12;
         public const float HorizontalPixelsBetweenControls = 12;
+        public const float VerticalPixelsBetweenControls = 4;
         public const float VerticalPixelsBetweenLabels = 2;
         public const float VerticalPixelsBetweenViews = 12;
         public const float StandardButtonWidth = 94;
@@ -55,6 +59,16 @@ namespace PresentScreenings.TableView
             cancelButton.Title = "Cancel";
             cancelButton.KeyEquivalent = EscapeKey;
             return cancelButton;
+        }
+
+        public static NSComboBox NewRatingComboBox(CGRect frame, NSFont font)
+        {
+            var comboBox = new NSComboBox(frame);
+            comboBox.Add(FilmRating.Values.Select(str => new NSString(str)).ToArray());
+            comboBox.Alignment = NSTextAlignment.Right;
+            comboBox.Font = font;
+            comboBox.AutoresizesSubviews = true;
+            return comboBox;
         }
 
         public static NSScrollView CreateStandardScrollView(CGRect frame, NSView documentView)

--- a/PresentScreenings/Main.storyboard
+++ b/PresentScreenings/Main.storyboard
@@ -702,11 +702,11 @@ DQ
                                         </tableView>
                                     </subviews>
                                 </clipView>
-                                <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="jsb-Kh-rpm">
+                                <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="jsb-Kh-rpm">
                                     <rect key="frame" x="1" y="713" width="1038" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="Dwc-dJ-kPy">
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="Dwc-dJ-kPy">
                                     <rect key="frame" x="224" y="17" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
@@ -761,43 +761,13 @@ DQ
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <button verticalHuggingPriority="750" tag="201" translatesAutoresizingMaskIntoConstraints="NO" id="yJN-Of-bHN" customClass="TitledButton">
-                                <rect key="frame" x="58" y="13" width="112" height="32"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="21" id="VDv-Zs-PFr"/>
-                                    <constraint firstAttribute="width" constant="100" id="rNO-Yk-QUA"/>
-                                </constraints>
-                                <buttonCell key="cell" type="push" title="Unattend" alternateTitle="Attend" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="9hX-uU-cTy">
-                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="IAttendScreening:" target="vU8-og-eGU" id="Z44-RR-JhO"/>
-                                </connections>
-                            </button>
-                            <button verticalHuggingPriority="750" tag="202" translatesAutoresizingMaskIntoConstraints="NO" id="Es9-Nb-gyH">
-                                <rect key="frame" x="170" y="13" width="72" height="32"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="60" id="t8h-EB-wOh"/>
-                                </constraints>
-                                <buttonCell key="cell" type="push" title="Done" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="EHD-jA-0hU">
-                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                    <string key="keyEquivalent" base64-UTF8="YES">
-DQ
-</string>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="AcceptDialog:" target="vU8-og-eGU" id="Upb-kg-Y2B"/>
-                                </connections>
-                            </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FBV-lJ-fAI">
                                 <rect key="frame" x="355" y="13" width="81" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="69" id="LJ8-MU-xu8"/>
                                     <constraint firstAttribute="width" constant="69" id="Vk5-xO-1fO"/>
                                 </constraints>
-                                <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="lEY-Ef-nVI">
+                                <buttonCell key="cell" type="push" title="Close" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="lEY-Ef-nVI">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                     <string key="keyEquivalent" base64-UTF8="YES">
@@ -919,12 +889,26 @@ Gw
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                             </button>
+                            <button verticalHuggingPriority="750" tag="201" translatesAutoresizingMaskIntoConstraints="NO" id="yJN-Of-bHN" customClass="TitledButton">
+                                <rect key="frame" x="243" y="13" width="112" height="32"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="VDv-Zs-PFr"/>
+                                    <constraint firstAttribute="width" constant="100" id="rNO-Yk-QUA"/>
+                                </constraints>
+                                <buttonCell key="cell" type="push" title="Unattend" alternateTitle="Attend" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="9hX-uU-cTy">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="IAttendScreening:" target="vU8-og-eGU" id="Z44-RR-JhO"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="FBV-lJ-fAI" firstAttribute="leading" secondItem="yJN-Of-bHN" secondAttribute="trailing" constant="12" id="1Iw-LB-wWw"/>
                             <constraint firstAttribute="trailing" secondItem="6dc-lf-7ip" secondAttribute="trailing" constant="20" id="22K-1v-yIJ"/>
                             <constraint firstItem="SM5-CE-qT9" firstAttribute="top" secondItem="X2t-8y-ItM" secondAttribute="top" constant="21" id="4vf-w5-X5p"/>
                             <constraint firstItem="Gm5-B4-fbz" firstAttribute="leading" secondItem="X2t-8y-ItM" secondAttribute="leading" constant="64" id="56h-ox-IAW"/>
-                            <constraint firstItem="Es9-Nb-gyH" firstAttribute="leading" secondItem="yJN-Of-bHN" secondAttribute="trailing" constant="12" id="7R6-mf-t04"/>
                             <constraint firstItem="SM5-CE-qT9" firstAttribute="leading" secondItem="X2t-8y-ItM" secondAttribute="leading" constant="64" id="8To-Il-CEx"/>
                             <constraint firstAttribute="bottom" secondItem="FBV-lJ-fAI" secondAttribute="bottom" constant="20" id="9o0-tz-kLa"/>
                             <constraint firstItem="LTo-dB-IYk" firstAttribute="top" secondItem="t67-Cz-8Dn" secondAttribute="bottom" constant="13" id="BXB-SN-nYh"/>
@@ -944,7 +928,6 @@ Gw
                             <constraint firstItem="VI4-Vt-R12" firstAttribute="leading" secondItem="X2t-8y-ItM" secondAttribute="leading" constant="64" id="deQ-eX-RDa"/>
                             <constraint firstItem="r1u-vm-oul" firstAttribute="top" secondItem="6dc-lf-7ip" secondAttribute="bottom" constant="6" id="fa0-1v-C5L"/>
                             <constraint firstAttribute="bottom" secondItem="yJN-Of-bHN" secondAttribute="bottom" constant="20" id="gB7-sH-e2J"/>
-                            <constraint firstAttribute="bottom" secondItem="Es9-Nb-gyH" secondAttribute="bottom" constant="20" id="gd3-Gq-crP"/>
                             <constraint firstItem="ipC-eH-G0f" firstAttribute="leading" secondItem="X2t-8y-ItM" secondAttribute="leading" constant="20" id="iaD-EZ-082"/>
                             <constraint firstAttribute="trailing" secondItem="ipC-eH-G0f" secondAttribute="trailing" constant="20" id="j3y-3w-47l"/>
                             <constraint firstItem="t67-Cz-8Dn" firstAttribute="leading" secondItem="X2t-8y-ItM" secondAttribute="leading" constant="20" id="pRl-e3-eFS"/>
@@ -955,7 +938,6 @@ Gw
                             <constraint firstItem="r1u-vm-oul" firstAttribute="top" secondItem="6dc-lf-7ip" secondAttribute="bottom" constant="6" id="rR1-t4-Td1"/>
                             <constraint firstAttribute="trailing" secondItem="Gm5-B4-fbz" secondAttribute="trailing" constant="20" id="rl8-wM-mUe"/>
                             <constraint firstAttribute="trailing" secondItem="hCw-vZ-7Dv" secondAttribute="trailing" constant="20" id="smg-8u-EzX"/>
-                            <constraint firstItem="yJN-Of-bHN" firstAttribute="leading" secondItem="X2t-8y-ItM" secondAttribute="leading" constant="64" id="tMe-eN-f3C"/>
                             <constraint firstItem="6dc-lf-7ip" firstAttribute="top" secondItem="hCw-vZ-7Dv" secondAttribute="bottom" constant="8" id="wYt-Rs-hxa"/>
                         </constraints>
                     </view>
@@ -1084,11 +1066,11 @@ Gw
                                     </subviews>
                                     <nil key="backgroundColor"/>
                                 </clipView>
-                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="cJC-90-VbM">
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="cJC-90-VbM">
                                     <rect key="frame" x="1" y="631" width="466" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="mxQ-38-gJg">
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="mxQ-38-gJg">
                                     <rect key="frame" x="224" y="17" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
@@ -1290,11 +1272,11 @@ Gw
                                     </subviews>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </clipView>
-                                <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="ZTS-pg-D15">
+                                <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="ZTS-pg-D15">
                                     <rect key="frame" x="1" y="101" width="442" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="3zv-0a-hdU">
+                                <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="3zv-0a-hdU">
                                     <rect key="frame" x="427" y="1" width="16" height="116"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
@@ -1356,13 +1338,13 @@ Gw
     </scenes>
     <resources>
         <image name="NSActionTemplate" width="14" height="14"/>
-        <image name="NSFolderSmart" width="128" height="128"/>
-        <image name="NSInfo" width="128" height="128"/>
-        <image name="NSNetwork" width="128" height="128"/>
+        <image name="NSFolderSmart" width="32" height="32"/>
+        <image name="NSInfo" width="32" height="32"/>
+        <image name="NSNetwork" width="32" height="32"/>
         <sound name="Glass"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="Aco-xL-TKu"/>
+        <segue reference="GdS-O0-lhM"/>
         <segue reference="MQZ-rL-cxz"/>
     </inferredMetricsTieBreakers>
 </document>


### PR DESCRIPTION
Aded a scroll view to ScreeningDialogController to contain the go-to-screening buttons and labels.
Unified the filling of the documentview (containing controls for all screenings involved) between ScreeningDialogController and FilmInfoDialogController, and put the code into abstract class GoToScreeningControllerView.
Refactored the creation of Friend Controls (Friend Rating combo boxes and Friend Attendance checkboxes) as to simplify the placement of the controls on their view.
Cloned the My Rating combo box from the one defined in Xcode and disposed the original, I could'n get the Friend Rating combo boxes clones look exactly like it.