### PR TITLE
Move linking to app delegate to AwakeFromNib()

### DIFF
--- a/PresentScreenings/Controllers/ViewController.cs
+++ b/PresentScreenings/Controllers/ViewController.cs
@@ -80,6 +80,9 @@ namespace PresentScreenings.TableView
         {
             base.AwakeFromNib();
 
+            // Tell the application delegate we're alive.
+            App.Controller = this;
+
             // Set the header text of the columns.
             _plan = new ScreeningsPlan();
             _mainView = new ScreeningsTableView(this, ScreensColumn, ScreeningsColumn);
@@ -117,8 +120,6 @@ namespace PresentScreenings.TableView
         public override void ViewWillAppear()
         {
             base.ViewWillAppear();
-
-            App.Controller = this;
         }
 
         public override void ViewWillDisappear()


### PR DESCRIPTION
## Problem
On MacOS 10.14.4 the application wouldn't run.
Appears to be the order in which ViewWillAppear() and AwakeFromNib() are called.

## Solution
Moved linking of the view controller from ViewWillAppear() to AwakeFromNib().