### PR TITLE
Make class ListStreamer non-generic

### DIFF
--- a/PresentScreenings/AppDelegate.cs
+++ b/PresentScreenings/AppDelegate.cs
@@ -94,9 +94,10 @@ namespace PresentScreenings.TableView
                 new ScreeningInfo().WriteListToFile(screeningInfosPath, ScreeningsPlan.ScreeningInfos);
 
                 // Write screenings summary.
-                string overviewPath = Path.Combine(directory, "Screenings Summary.csv");
-                new Screening().WriteListToFile(overviewPath, Controller.Plan.AttendedScreenings());
+                string summaryPath = Path.Combine(directory, "Screenings Summary.csv");
+                new Screening().WriteListToFile(summaryPath, Controller.Plan.AttendedScreenings());
             });
+
         }
 
         partial void ToggleClickableLabels(Foundation.NSObject sender)

--- a/PresentScreenings/Entities/Film.cs
+++ b/PresentScreenings/Entities/Film.cs
@@ -6,7 +6,7 @@ namespace PresentScreenings.TableView
     /// Keeps information about a film and supports international sorting and personal rating.
     /// </summary>
 
-    public class Film : ListStreamer<Film>
+    public class Film : ListStreamer
     {
         #region Public Members
         public enum FilmInfoStatus

--- a/PresentScreenings/Entities/FilmFanFilmRating.cs
+++ b/PresentScreenings/Entities/FilmFanFilmRating.cs
@@ -2,7 +2,7 @@
 
 namespace PresentScreenings.TableView
 {
-    public class FilmFanFilmRating : ListStreamer<FilmFanFilmRating>
+    public class FilmFanFilmRating : ListStreamer
     {
         #region Properties
         public int FilmId { get; }

--- a/PresentScreenings/Entities/Screen.cs
+++ b/PresentScreenings/Entities/Screen.cs
@@ -7,7 +7,7 @@ namespace PresentScreenings.TableView
 	/// Holds the information of a theater screen where a movie screening plays.
 	/// </summary>
 
-    public class Screen : ListStreamer<Screen>, IComparable
+    public class Screen : ListStreamer, IComparable
 	{
         #region Properties
         public string ParseName { get; }

--- a/PresentScreenings/Entities/Screening.cs
+++ b/PresentScreenings/Entities/Screening.cs
@@ -12,7 +12,7 @@ namespace PresentScreenings.TableView
     /// screening is attended at the same time or the film is already planned.
     /// </summary>
 
-    public class Screening : ListStreamer<Screening>, IComparable
+    public class Screening : ListStreamer, IComparable
     {
         #region Constant Private Members
         private const string _dateFormat = "yyyy-MM-dd";

--- a/PresentScreenings/Entities/ScreeningInfo.cs
+++ b/PresentScreenings/Entities/ScreeningInfo.cs
@@ -9,7 +9,7 @@ namespace PresentScreenings.TableView
     /// attendabilty, hiding how these are represented in the screenings file.
     /// </summary>
 
-    public class ScreeningInfo : ListStreamer<ScreeningInfo>
+    public class ScreeningInfo : ListStreamer
     {
         #region Public Members
         public enum ScreeningStatus

--- a/PresentScreenings/ListStreamer.cs
+++ b/PresentScreenings/ListStreamer.cs
@@ -8,7 +8,7 @@ namespace PresentScreenings.TableView
     /// List streamer, read/write files based on list of derived objects.
     /// </summary>
 
-    public abstract class ListStreamer<T>  where T : ListStreamer<T>, new()
+    public abstract class ListStreamer
     {
         #region Virtual Methods
         public virtual bool ListFileIsMandatory()
@@ -33,7 +33,7 @@ namespace PresentScreenings.TableView
         #endregion
 
         #region Public Methods
-        public List<T> ReadListFromFile(string fileName, Func<string, T> lineConstructor)
+        public List<T> ReadListFromFile<T>(string fileName, Func<string, T> lineConstructor) where T : ListStreamer
         {
             var resultList = new List<T> { };
 			using (var streamReader = GetStreamReader(fileName))
@@ -56,7 +56,7 @@ namespace PresentScreenings.TableView
 			return resultList;
 		}
 
-        public void WriteListToFile(string fileName, List<T> list)
+        public void WriteListToFile<T>(string fileName, List<T> list) where T : ListStreamer
         {
             using (var streamWriter = GetStreamWriter(fileName))
             {


### PR DESCRIPTION
Class is now non-generic, but the read and write functions now need to be generic.
Probably because `List<T1>` cannot converted to `List<T2>`.