### PR TITLE
Fix download menu item

### DIFF
--- a/PresentScreenings/AppDelegate.cs
+++ b/PresentScreenings/AppDelegate.cs
@@ -61,7 +61,6 @@ namespace PresentScreenings.TableView
             _showScreeningsMenuItem.Action = new Selector("ShowScreenings:");
             _combineTitlesMenuItem.Action = new Selector("SelectTitlesToCombine:");
             _uncombineTitleMenuItem.Action = new Selector("ShowTitlesToUncombine:");
-            _downloadFilmInfoMenuItem.Action = new Selector("OpenDownloadFilmInfo:");
             Controller.ClickableLabelsMenuItem = _clickableLabelsMenuItem;
 		}
         
@@ -120,11 +119,6 @@ namespace PresentScreenings.TableView
         partial void ToggleClickableLabels(Foundation.NSObject sender)
         {
             Controller.ToggleClickableLabels();
-        }
-
-        partial void DownloadFilmInfo(Foundation.NSObject sender)
-        {
-            Controller.DownloadFilmInfo(sender);
         }
 
         partial void ShowScreeningInfo(Foundation.NSObject sender)
@@ -199,5 +193,5 @@ namespace PresentScreenings.TableView
             Controller.ToggleAttendance(filmFan);
         }
         #endregion
-	}
+    }
 }

--- a/PresentScreenings/AppDelegate.cs
+++ b/PresentScreenings/AppDelegate.cs
@@ -61,6 +61,7 @@ namespace PresentScreenings.TableView
             _showScreeningsMenuItem.Action = new Selector("ShowScreenings:");
             _combineTitlesMenuItem.Action = new Selector("SelectTitlesToCombine:");
             _uncombineTitleMenuItem.Action = new Selector("ShowTitlesToUncombine:");
+            _downloadFilmInfoMenuItem.Action = new Selector("OpenDownloadFilmInfo:");
             Controller.ClickableLabelsMenuItem = _clickableLabelsMenuItem;
 		}
         
@@ -121,7 +122,7 @@ namespace PresentScreenings.TableView
             Controller.ToggleClickableLabels();
         }
 
-        partial void DownloadFilmInfo(NSObject sender)
+        partial void DownloadFilmInfo(Foundation.NSObject sender)
         {
             Controller.DownloadFilmInfo(sender);
         }

--- a/PresentScreenings/AppDelegate.designer.cs
+++ b/PresentScreenings/AppDelegate.designer.cs
@@ -21,9 +21,6 @@ namespace PresentScreenings.TableView
 		AppKit.NSMenuItem _combineTitlesMenuItem { get; set; }
 
 		[Outlet]
-		AppKit.NSMenuItem _downloadFilmInfoMenuItem { get; set; }
-
-		[Outlet]
 		AppKit.NSMenu _filmsMenu { get; set; }
 
 		[Outlet]
@@ -113,11 +110,6 @@ namespace PresentScreenings.TableView
 			if (_combineTitlesMenuItem != null) {
 				_combineTitlesMenuItem.Dispose ();
 				_combineTitlesMenuItem = null;
-			}
-
-			if (_downloadFilmInfoMenuItem != null) {
-				_downloadFilmInfoMenuItem.Dispose ();
-				_downloadFilmInfoMenuItem = null;
 			}
 
 			if (_filmsMenu != null) {

--- a/PresentScreenings/AppDelegate.designer.cs
+++ b/PresentScreenings/AppDelegate.designer.cs
@@ -21,6 +21,9 @@ namespace PresentScreenings.TableView
 		AppKit.NSMenuItem _combineTitlesMenuItem { get; set; }
 
 		[Outlet]
+		AppKit.NSMenuItem _downloadFilmInfoMenuItem { get; set; }
+
+		[Outlet]
 		AppKit.NSMenu _filmsMenu { get; set; }
 
 		[Outlet]
@@ -110,6 +113,11 @@ namespace PresentScreenings.TableView
 			if (_combineTitlesMenuItem != null) {
 				_combineTitlesMenuItem.Dispose ();
 				_combineTitlesMenuItem = null;
+			}
+
+			if (_downloadFilmInfoMenuItem != null) {
+				_downloadFilmInfoMenuItem.Dispose ();
+				_downloadFilmInfoMenuItem = null;
 			}
 
 			if (_filmsMenu != null) {

--- a/PresentScreenings/Controllers/FilmRatingDialogController.cs
+++ b/PresentScreenings/Controllers/FilmRatingDialogController.cs
@@ -440,8 +440,14 @@ namespace PresentScreenings.TableView
             PerformSegue("GoToScreeningSegue", sender);
         }
 
-        [Action("DownLoadInfoForOneFilm:")]
+        [Action("DownloadFilmInfo:")]
         void DownloadFilmInfo(NSObject sender)
+        {
+            PerformSegue("DownloadFilmInfoSegue", sender);
+        }
+
+        [Action("DownLoadInfoForOneFilm:")]
+        void DownLoadInfoForOneFilm(NSObject sender)
         {
             PerformSegue("DownloadFilmInfoSegue", sender);
         }

--- a/PresentScreenings/Controllers/FilmRatingDialogController.cs
+++ b/PresentScreenings/Controllers/FilmRatingDialogController.cs
@@ -77,7 +77,6 @@ namespace PresentScreenings.TableView
             _combineTitlesButton.Action = new ObjCRuntime.Selector("SelectTitlesToCombine:");
             _uncombineTitleButton.Action = new ObjCRuntime.Selector("ShowTitlesToUncombine:");
             _goToScreeningButton.Action = new ObjCRuntime.Selector("ShowScreenings:");
-            //_downloadFilmInfoButton.Action = new ObjCRuntime.Selector("DownLoadInfoForOneFilm:");
             _downloadFilmInfoButton.Action = new ObjCRuntime.Selector("OpenDownloadFilmInfo:");
             DoneButton.KeyEquivalent = ControlsFactory.EscapeKey;
             DoneButton.StringValue = "Noot";
@@ -443,12 +442,6 @@ namespace PresentScreenings.TableView
 
         [Action("OpenDownloadFilmInfo:")]
         void OpenDownloadFilmInfo(NSObject sender)
-        {
-            PerformSegue("DownloadFilmInfoSegue", sender);
-        }
-
-        [Action("DownLoadInfoForOneFilm:")]
-        void DownLoadInfoForOneFilm(NSObject sender)
         {
             PerformSegue("DownloadFilmInfoSegue", sender);
         }

--- a/PresentScreenings/Controllers/FilmRatingDialogController.cs
+++ b/PresentScreenings/Controllers/FilmRatingDialogController.cs
@@ -77,7 +77,8 @@ namespace PresentScreenings.TableView
             _combineTitlesButton.Action = new ObjCRuntime.Selector("SelectTitlesToCombine:");
             _uncombineTitleButton.Action = new ObjCRuntime.Selector("ShowTitlesToUncombine:");
             _goToScreeningButton.Action = new ObjCRuntime.Selector("ShowScreenings:");
-            _downloadFilmInfoButton.Action = new ObjCRuntime.Selector("DownLoadInfoForOneFilm:");
+            //_downloadFilmInfoButton.Action = new ObjCRuntime.Selector("DownLoadInfoForOneFilm:");
+            _downloadFilmInfoButton.Action = new ObjCRuntime.Selector("OpenDownloadFilmInfo:");
             DoneButton.KeyEquivalent = ControlsFactory.EscapeKey;
             DoneButton.StringValue = "Noot";
             SetTypeMatchMethodControlStates();
@@ -440,8 +441,8 @@ namespace PresentScreenings.TableView
             PerformSegue("GoToScreeningSegue", sender);
         }
 
-        [Action("DownloadFilmInfo:")]
-        void DownloadFilmInfo(NSObject sender)
+        [Action("OpenDownloadFilmInfo:")]
+        void OpenDownloadFilmInfo(NSObject sender)
         {
             PerformSegue("DownloadFilmInfoSegue", sender);
         }

--- a/PresentScreenings/Controllers/ViewController.cs
+++ b/PresentScreenings/Controllers/ViewController.cs
@@ -499,11 +499,6 @@ namespace PresentScreenings.TableView
             ReloadScreeningsView();
         }
 
-        public void DownloadFilmInfo(NSObject sender)
-        {
-            App.FilmsDialogController?.PerformSegue("DownloadFilmInfoSegue", sender);
-        }
-
         [Action("ShowFilmRatings:")]
         internal void ShowFilmRating(NSObject sender)
         {

--- a/PresentScreenings/Main.storyboard
+++ b/PresentScreenings/Main.storyboard
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -382,8 +381,7 @@
                                         <menuItem title="Combine Titles" tag="504" keyEquivalent="k" id="sG4-4A-cBU"/>
                                         <menuItem title="Uncombine Title" tag="505" keyEquivalent="K" id="NR9-b1-rZW"/>
                                         <menuItem isSeparatorItem="YES" id="2qy-BY-Op3"/>
-                                        <menuItem title="Download Film Info" tag="506" keyEquivalent="I" id="6tr-b1-Qmi">
-                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                        <menuItem title="Download Film Info" tag="506" keyEquivalent="d" id="6tr-b1-Qmi">
                                             <connections>
                                                 <action selector="DownloadFilmInfo:" target="Voe-Tx-rLC" id="ajd-88-dBc"/>
                                             </connections>
@@ -523,6 +521,7 @@
                         <outlet property="_clickableLabelsMenuItem" destination="CSW-Sl-2GZ" id="cMX-lr-wYA"/>
                         <outlet property="_closeWindowMenuItem" destination="DVo-aG-piG" id="Daa-2x-NT9"/>
                         <outlet property="_combineTitlesMenuItem" destination="sG4-4A-cBU" id="V2D-4S-BS1"/>
+                        <outlet property="_downloadFilmInfoMenuItem" destination="6tr-b1-Qmi" id="Hde-qu-GxV"/>
                         <outlet property="_filmsMenu" destination="H0R-t1-cOF" id="c2J-k7-sDI"/>
                         <outlet property="_navigateMenu" destination="FJw-Lu-hGY" id="tRh-KN-Ggw"/>
                         <outlet property="_plannerMenuItem" destination="1oz-bg-aQu" id="nQZ-wQ-Ryi"/>
@@ -542,7 +541,7 @@
                 <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <userDefaultsController representsSharedInstance="YES" id="sZm-qZ-jgu"/>
             </objects>
-            <point key="canvasLocation" x="248" y="-145"/>
+            <point key="canvasLocation" x="240" y="-138"/>
         </scene>
         <!--Planner-->
         <scene sceneID="3La-aE-ipS">
@@ -1192,6 +1191,9 @@ DQ
                                     <string key="keyEquivalent">i</string>
                                     <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 </buttonCell>
+                                <connections>
+                                    <action selector="DownloadFilmInfo:" target="gJ5-Ju-597" id="6mj-t5-RRl"/>
+                                </connections>
                             </button>
                         </subviews>
                         <constraints>
@@ -1538,7 +1540,7 @@ Gw
                 </viewController>
                 <customObject id="jp2-L0-Ogz" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3831" y="409"/>
+            <point key="canvasLocation" x="2268" y="402"/>
         </scene>
     </scenes>
     <resources>

--- a/PresentScreenings/Main.storyboard
+++ b/PresentScreenings/Main.storyboard
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -381,11 +382,6 @@
                                         <menuItem title="Combine Titles" tag="504" keyEquivalent="k" id="sG4-4A-cBU"/>
                                         <menuItem title="Uncombine Title" tag="505" keyEquivalent="K" id="NR9-b1-rZW"/>
                                         <menuItem isSeparatorItem="YES" id="2qy-BY-Op3"/>
-                                        <menuItem title="Download Film Info" tag="506" keyEquivalent="d" id="6tr-b1-Qmi">
-                                            <connections>
-                                                <action selector="DownloadFilmInfo:" target="Voe-Tx-rLC" id="ajd-88-dBc"/>
-                                            </connections>
-                                        </menuItem>
                                     </items>
                                 </menu>
                             </menuItem>
@@ -521,7 +517,6 @@
                         <outlet property="_clickableLabelsMenuItem" destination="CSW-Sl-2GZ" id="cMX-lr-wYA"/>
                         <outlet property="_closeWindowMenuItem" destination="DVo-aG-piG" id="Daa-2x-NT9"/>
                         <outlet property="_combineTitlesMenuItem" destination="sG4-4A-cBU" id="V2D-4S-BS1"/>
-                        <outlet property="_downloadFilmInfoMenuItem" destination="6tr-b1-Qmi" id="Hde-qu-GxV"/>
                         <outlet property="_filmsMenu" destination="H0R-t1-cOF" id="c2J-k7-sDI"/>
                         <outlet property="_navigateMenu" destination="FJw-Lu-hGY" id="tRh-KN-Ggw"/>
                         <outlet property="_plannerMenuItem" destination="1oz-bg-aQu" id="nQZ-wQ-Ryi"/>

--- a/PresentScreenings/Menu Delegates/FilmsMenuDelegate.cs
+++ b/PresentScreenings/Menu Delegates/FilmsMenuDelegate.cs
@@ -34,10 +34,10 @@ namespace PresentScreenings.TableView
 
         public override void NeedsUpdate(NSMenu menu)
         {
-            // Replace the DownLoad Film Info menu item.
+            // Add the DownLoad Film Info menu item.
             if (!_initialized)
             {
-                ReplaceDownloadMenuItem(menu);
+                AddDownloadMenuItem(menu);
                 _initialized = true;
             }
 
@@ -82,19 +82,13 @@ namespace PresentScreenings.TableView
         #endregion
 
         #region Private Methods
-        private void ReplaceDownloadMenuItem(NSMenu menu)
+        private void AddDownloadMenuItem(NSMenu menu)
         {
-            // Remove the malfuctioning menunitem.
-            var oldItem = menu.ItemWithTag(_downloadFilmInfoMenuItemTag);
-            var title = oldItem.Title;
-            var keyEquivalent = oldItem.KeyEquivalent;
-            menu.RemoveItem(menu.ItemWithTag(_downloadFilmInfoMenuItemTag));
-
-            // Add the replacement.
+            var title = "Download Film Info";
             var newItem = new NSMenuItem(title);
             newItem.Action = new ObjCRuntime.Selector("OpenDownloadFilmInfo:");
             newItem.Tag = _downloadFilmInfoMenuItemTag;
-            newItem.KeyEquivalent = keyEquivalent;
+            newItem.KeyEquivalent = "d";
             menu.AddItem(newItem);
         }
         #endregion

--- a/PresentScreenings/Menu Delegates/FilmsMenuDelegate.cs
+++ b/PresentScreenings/Menu Delegates/FilmsMenuDelegate.cs
@@ -10,13 +10,14 @@ namespace PresentScreenings.TableView
     public class FilmsMenuDelegate : NSMenuDelegate
     {
         #region Private Members
-        const int _showFilmsMenuItemTag = 501;
-        const int _toggleTypeMatchMethodMenuItemTag = 502;
-        const int _showFilmInfoMenuItemTag = 503;
-        const int _combineTitlesMenuItemTag = 504;
-        const int _uncombineTitleMenuItemTag = 505;
-        const int _downloadFilmInfoMenuItemTag = 506;
-        AppDelegate _app;
+        private const int _showFilmsMenuItemTag = 501;
+        private const int _toggleTypeMatchMethodMenuItemTag = 502;
+        private const int _showFilmInfoMenuItemTag = 503;
+        private const int _combineTitlesMenuItemTag = 504;
+        private const int _uncombineTitleMenuItemTag = 505;
+        private const int _downloadFilmInfoMenuItemTag = 506;
+        private bool _initialized = false;
+        private readonly AppDelegate _app;
         #endregion
 
         #region Constructors
@@ -33,6 +34,13 @@ namespace PresentScreenings.TableView
 
         public override void NeedsUpdate(NSMenu menu)
         {
+            // Replace the DownLoad Film Info menu item.
+            if (!_initialized)
+            {
+                ReplaceDownloadMenuItem(menu);
+                _initialized = true;
+            }
+
             // Process every item in the menu
             foreach (NSMenuItem item in menu.Items)
             {
@@ -70,6 +78,24 @@ namespace PresentScreenings.TableView
                         break;
                 }
             }
+        }
+        #endregion
+
+        #region Private Methods
+        private void ReplaceDownloadMenuItem(NSMenu menu)
+        {
+            // Remove the malfuctioning menunitem.
+            var oldItem = menu.ItemWithTag(_downloadFilmInfoMenuItemTag);
+            var title = oldItem.Title;
+            var keyEquivalent = oldItem.KeyEquivalent;
+            menu.RemoveItem(menu.ItemWithTag(_downloadFilmInfoMenuItemTag));
+
+            // Add the replacement.
+            var newItem = new NSMenuItem(title);
+            newItem.Action = new ObjCRuntime.Selector("OpenDownloadFilmInfo:");
+            newItem.Tag = _downloadFilmInfoMenuItemTag;
+            newItem.KeyEquivalent = keyEquivalent;
+            menu.AddItem(newItem);
         }
         #endregion
     }

--- a/PresentScreenings/Menu Delegates/ScreeningMenuDelegate.cs
+++ b/PresentScreenings/Menu Delegates/ScreeningMenuDelegate.cs
@@ -64,7 +64,7 @@ namespace PresentScreenings.TableView
                 : AnalyserViewRunning() ? (IScreeningProvider)AnalyserDialogController
                 : _controller;
 
-            //Get the current film.
+            // Get the current film.
             var currFilm = _screeningProvider.CurrentFilm;
             if (currFilm != _film)
             {


### PR DESCRIPTION
## Problem
The Download Film Info menu item as created with Xcode didn't provoke any action.

## Fix
- Remove the menu item from Xcode
- Add it in-code in `FilmsMenuDelegate`
- Clean-up code that is unused now.