### PR TITLE
Use user notification instead of sound

### DIFF
--- a/PresentScreenings/AppDelegate.cs
+++ b/PresentScreenings/AppDelegate.cs
@@ -19,6 +19,7 @@ namespace PresentScreenings.TableView
         #region Static Properties
         public static string Festival { get; private set; }
         public static string FestivalYear { get; private set; }
+        public static string DocumentsFolder => GetDocumentsPath();
         #endregion
 
         #region Properties
@@ -44,6 +45,14 @@ namespace PresentScreenings.TableView
             FilmRatingDialogController.OnlyFilmsWithScreenings = true;
             FilmRatingDialogController.MinimalDuration = new TimeSpan(0, 35, 0);
             ScreeningControl.UseCoreGraphics = false;
+        }
+        #endregion
+
+        #region Private Methods
+        private static string GetDocumentsPath()
+        {
+            string homeFolder = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+            return homeFolder + $"/Documents/Film/{Festival}/{Festival}{FestivalYear}/FestivalPlan";
         }
         #endregion
 

--- a/PresentScreenings/Controllers/ViewController.cs
+++ b/PresentScreenings/Controllers/ViewController.cs
@@ -82,7 +82,7 @@ namespace PresentScreenings.TableView
             DisposeColorLabels();
 
             // Create the screenings plan.
-            _plan = new ScreeningsPlan(AppDelegate.Festival, AppDelegate.FestivalYear);
+            _plan = new ScreeningsPlan(AppDelegate.DocumentsFolder);
 
             // Create the screenings table view and draw the headers.
             _mainView = new ScreeningsTableView(this, ScreensColumn, ScreeningsColumn);

--- a/PresentScreenings/Entities/ScreeningsPlan.cs
+++ b/PresentScreenings/Entities/ScreeningsPlan.cs
@@ -41,17 +41,15 @@ namespace PresentScreenings.TableView
         #endregion
 
         #region Constructors
-        public ScreeningsPlan(string festival, string FestivalYear)
+        public ScreeningsPlan(string documentsFolder)
         {
             // Initialize file names.
-            string homeFolder = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-            string directory = homeFolder + $"/Documents/Film/{festival}/{festival}{FestivalYear}/FestivalPlan";
-            string screensFile = Path.Combine(directory, "screens.csv");
-            string filmsFile = Path.Combine(directory, "films.csv");
-            string screeningsFile = Path.Combine(directory, "screenings.csv");
-            string screeningInfoFile = Path.Combine(directory, "screeninginfo.csv");
-            string ratingsFile = Path.Combine(directory, "ratings.csv");
-            string filmInfoFile = Path.Combine(directory, "filminfo.xml");
+            string screensFile = Path.Combine(documentsFolder, "screens.csv");
+            string filmsFile = Path.Combine(documentsFolder, "films.csv");
+            string screeningsFile = Path.Combine(documentsFolder, "screenings.csv");
+            string screeningInfoFile = Path.Combine(documentsFolder, "screeninginfo.csv");
+            string ratingsFile = Path.Combine(documentsFolder, "ratings.csv");
+            string filmInfoFile = Path.Combine(documentsFolder, "filminfo.xml");
 
             // Read screens.
             Screens = new Screen().ReadListFromFile(screensFile, line => new Screen(line));

--- a/PresentScreenings/Info.plist
+++ b/PresentScreenings/Info.plist
@@ -28,5 +28,9 @@
 	<string>Main</string>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/AppIcon.appiconset</string>
+	<key>CFBundleDisplayName</key>
+	<string>PlanScreenings</string>
+	<key>NSUserNotificationAlertStyle</key>
+	<string>alert</string>
 </dict>
 </plist>

--- a/PresentScreenings/Main.cs
+++ b/PresentScreenings/Main.cs
@@ -7,12 +7,9 @@ using Foundation;
 namespace PresentScreenings.TableView
 {
     static class MainClass
-	{
-        static string ProgramName => Path.GetFileNameWithoutExtension(Environment.GetCommandLineArgs()[0]);
-        static string ErrorFile => Path.Combine(AppDelegate.DocumentsFolder, @"error.txt");
-
+    {
         static void Main(string[] args)
-		{
+        {
             try
             {
                 NSApplication.Init();
@@ -20,62 +17,8 @@ namespace PresentScreenings.TableView
             }
             catch (Exception ex)
             {
-                WriteToErrorlog(ex);
-                RaiseAlert(ex);
+                AlertRaiser.LandApplication(ex);
             }
-            NSApplication.SharedApplication.Terminate(NSApplication.SharedApplication);
-		}
-
-        public static void RaiseAlert(Exception ex)
-        {
-            var alert = new NSAlert()
-            {
-                AlertStyle = NSAlertStyle.Critical,
-                InformativeText = ex.ToString(),
-                MessageText = $"Error in {ProgramName}."
-            };
-            try
-            {
-                alert.RunModal();
-            }
-            catch (Exception ex2)
-            {
-                WriteToErrorlog(ex, ex2);
-                RaiseNotification(ex);
-            }
-        }
-
-        public static void WriteToErrorlog(Exception ex, Exception ex2 = null)
-        {
-            System.IO.File.WriteAllText(ErrorFile, ErrorString(ex, ex2));
-        }
-
-        public static void RaiseNotification(Exception ex)
-        {
-            // Trigger a local notification.
-            var notification = new NSUserNotification
-            {
-                Title = $"Error in {ProgramName}.",
-                InformativeText = $"See {ErrorFile}.",
-                SoundName = NSUserNotification.NSUserNotificationDefaultSoundName,
-                HasActionButton = false,
-                HasReplyButton = false
-            };
-            NSUserNotificationCenter.DefaultUserNotificationCenter.DeliverNotification(notification);
-        }
-
-        private static string ErrorString(Exception ex, Exception ex2 = null)
-        {
-            var builder = new StringBuilder();
-            builder.AppendLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
-            builder.AppendLine();
-            builder.AppendLine(ex.ToString());
-            if (ex2 != null)
-            {
-                builder.AppendLine();
-                builder.AppendLine(ex2.ToString());
-            }
-            return builder.ToString();
         }
     }
 }

--- a/PresentScreenings/Main.cs
+++ b/PresentScreenings/Main.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Text;
 using AppKit;
-using AVFoundation;
 using Foundation;
 
 namespace PresentScreenings.TableView

--- a/PresentScreenings/PresentScreenings.csproj
+++ b/PresentScreenings/PresentScreenings.csproj
@@ -171,6 +171,7 @@
     <Compile Include="Utilities\ScreeningsPlanner.cs" />
     <Compile Include="Utilities\WebUtility.cs" />
     <Compile Include="Table Classes\FilmOutlineLevel.cs" />
+    <Compile Include="Utilities\AlertRaiser.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Main.storyboard" />

--- a/PresentScreenings/Utilities/AlertRaiser.cs
+++ b/PresentScreenings/Utilities/AlertRaiser.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using AppKit;
+using Foundation;
+
+namespace PresentScreenings.TableView
+{
+    /// <summary>
+    /// Alert Raiser, stops the application after writing a stack dump on file
+    /// and displaying an alert.
+    /// If no alert can be displayed, a usrr notification is raised.
+    /// </summary>
+    public static class AlertRaiser
+    {
+        #region Properties
+        static string ProgramName => Path.GetFileNameWithoutExtension(Environment.GetCommandLineArgs()[0]);
+        static string ErrorFile => Path.Combine(AppDelegate.DocumentsFolder, @"error.txt");
+        #endregion
+
+        #region Constructors
+        static AlertRaiser()
+        {
+        }
+        #endregion
+
+        #region Public Methods
+        public static void LandApplication(Exception ex)
+        {
+            WriteToErrorlog(ex);
+            RaiseAlert(ex);
+            NSApplication.SharedApplication.Terminate(NSApplication.SharedApplication);
+        }
+
+        public static void RaiseAlert(Exception ex)
+        {
+            var alert = new NSAlert()
+            {
+                AlertStyle = NSAlertStyle.Critical,
+                InformativeText = ex.ToString(),
+                MessageText = $"Error in {ProgramName}."
+            };
+            try
+            {
+                alert.RunModal();
+            }
+            catch (Exception ex2)
+            {
+                WriteToErrorlog(ex, ex2);
+                RaiseNotification(ex);
+            }
+        }
+
+        public static void WriteToErrorlog(Exception ex, Exception ex2 = null)
+        {
+            System.IO.File.WriteAllText(ErrorFile, ErrorString(ex, ex2));
+        }
+
+        public static void RaiseNotification(Exception ex)
+        {
+            // Trigger a local notification.
+            // Configure the notification style in System Preferences.
+            var notification = new NSUserNotification
+            {
+                Title = $"Error in {ProgramName}.",
+                InformativeText = $"See {ErrorFile}.",
+                SoundName = NSUserNotification.NSUserNotificationDefaultSoundName,
+                HasActionButton = false,
+                HasReplyButton = false
+            };
+            NSUserNotificationCenter.DefaultUserNotificationCenter.DeliverNotification(notification);
+        }
+        #endregion
+
+        #region Private Methods
+        private static string ErrorString(Exception ex, Exception ex2 = null)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
+            builder.AppendLine();
+            builder.AppendLine(ex.ToString());
+            if (ex2 != null)
+            {
+                builder.AppendLine();
+                builder.AppendLine(ex2.ToString());
+            }
+            return builder.ToString();
+        }
+        #endregion
+    }
+}

--- a/Resources/Crash.mp3
+++ b/Resources/Crash.mp3
@@ -1,1 +1,0 @@
-/Users/maarten/Documents/Resources/Crash.mp3


### PR DESCRIPTION
PresentScreenings/Entities/ScreeningsPlan.cs:
Move resposibility to define documents directory to the app delegate.

PresentScreenings/Info.plist:
Set user notification style to alert.

PresentScreenings/Main.cs:
Use user notification instead of sound when an alert is not possible.

Resources/Crash.mp3:
No longer use a sound resource.