### PR TITLE
Complilation IDs in screened screenings

### DIFF
--- a/FilmFestivalLoader/IDFA/Movies To IDFA Agenda2020.scpt
+++ b/FilmFestivalLoader/IDFA/Movies To IDFA Agenda2020.scpt
@@ -112,3 +112,4 @@ end repeat
 
 
 
+

--- a/FilmFestivalLoader/IFFR/parse_iffr_html.py
+++ b/FilmFestivalLoader/IFFR/parse_iffr_html.py
@@ -62,6 +62,10 @@ def main():
     except KeyboardInterrupt:
         comment("Interrupted from keyboard... exiting")
         write_other_lists = False
+    except Exception as e:
+        Globals.debug_recorder.write_debug()
+        comment('Debug info printed.')
+        raise e
     else:
         write_film_list = True
 
@@ -136,8 +140,8 @@ class FilmDetailsLoader:
 
     def get_film_details(self, iffr_data):
         for film in iffr_data.films:
-            if film.filmid not in [1, 18, 123, 124, 175, 438, 572, 659, 688, 692]:
-                continue
+            # if film.filmid not in [1, 18, 123, 124, 175, 438, 572, 659, 688, 692]:
+            #     continue
             html_data = None
             film_file = film_file_format.format(film.filmid)
             if os.path.isfile(film_file):
@@ -296,10 +300,15 @@ class FilmPageParser(HtmlPageParser):
 
     def add_screened_film(self):
         print(f'Found screened film: {self.screened_title}')
-        film = self.iffr_data.get_film_by_key(self.screened_title, self.screened_url)
-        screened_film = planner.ScreenedFilm(film.filmid, self.screened_title, self.screened_description)
-        self.screened_films.append(screened_film)
-        self.init_screened_film_data()
+        try:
+            film = self.iffr_data.get_film_by_key(self.screened_title, self.screened_url)
+        except KeyError:
+            Globals.error_collector.add('No screened URL found', f'{self.screened_title}')
+        else:
+            screened_film = planner.ScreenedFilm(film.filmid, self.screened_title, self.screened_description)
+            self.screened_films.append(screened_film)
+        finally:
+            self.init_screened_film_data()
 
     def add_screening(self):
         start_datetime = datetime.datetime.combine(self.start_date, self.start_time)
@@ -318,7 +327,10 @@ class FilmPageParser(HtmlPageParser):
         print(f"--  q and a:    {self.qa}")
         print(f"--  extra:      {self.extra}")
 
-        screening = planner.Screening(self.film, self.screen, start_datetime, end_datetime, self.qa, self.extra, self.audience)
+        program = None
+        if self.film.combination_url is not None:
+            program = self.iffr_data.get_film_by_key(None, self.film.combination_url)
+        screening = planner.Screening(self.film, self.screen, start_datetime, end_datetime, self.qa, self.extra, self.audience, program)
 
         self.iffr_data.screenings.append(screening)
         print("---SCREENING ADDED")
@@ -328,8 +340,8 @@ class FilmPageParser(HtmlPageParser):
     def ok_to_add_screening(self):
         if self.audience is None:
             return False
-        if len(self.film.combination_url) > 0:
-            return False
+        # if len(self.film.combination_url) > 0:
+        #     return False
         if self.extra == "Voorfilm: " + self.film.title:
             return False
         if not include_events and self.film.medium_category == "events":

--- a/FilmFestivalLoader/IFFR/parse_iffr_html.py
+++ b/FilmFestivalLoader/IFFR/parse_iffr_html.py
@@ -140,8 +140,8 @@ class FilmDetailsLoader:
 
     def get_film_details(self, iffr_data):
         for film in iffr_data.films:
-            # if film.filmid not in [1, 18, 123, 124, 175, 438, 572, 659, 688, 692]:
-            #     continue
+            if film.filmid not in [1, 18, 123, 124, 175, 438, 572, 659, 688, 692]:
+                continue
             html_data = None
             film_file = film_file_format.format(film.filmid)
             if os.path.isfile(film_file):
@@ -340,8 +340,6 @@ class FilmPageParser(HtmlPageParser):
     def ok_to_add_screening(self):
         if self.audience is None:
             return False
-        # if len(self.film.combination_url) > 0:
-        #     return False
         if self.extra == "Voorfilm: " + self.film.title:
             return False
         if not include_events and self.film.medium_category == "events":

--- a/FilmFestivalLoader/Shared/planner_interface.py
+++ b/FilmFestivalLoader/Shared/planner_interface.py
@@ -383,7 +383,6 @@ class FestivalData:
     def write_screenings(self):
         public_screenings = []
         if len(self.screenings):
-            # public_screenings = [s for s in self.screenings if s.audience == "publiek" and s.combination_program is None]
             public_screenings = [s for s in self.screenings if s.audience == "publiek"]
             with open(self.screenings_file, 'w') as f:
                 f.write(self.screenings[0].screening_repr_csv_head())

--- a/FilmFestivalLoader/Shared/planner_interface.py
+++ b/FilmFestivalLoader/Shared/planner_interface.py
@@ -67,11 +67,11 @@ class Film:
         self.section = ""
         self.duration = None
         self.medium_category = url.split("/")[5]
-        self.combination_url = ""
+        self.combination_url = None
         self.sortstring = self.lower(self.strip_article())
 
     def __str__(self):
-        return "; ".join([self.title, self.medium_category, self.combination_url])
+        return "; ".join([self.title, self.medium_category, '' if self.combination_url is None else self.combination_url])
 
     def __lt__(self, other):
         self_is_alpha = self.re_alpha.match(self.sortstring) is not None
@@ -288,7 +288,6 @@ class FestivalData:
                 title = record[3]
                 url = record[8]
                 self.filmid_by_url[url] = filmid
-#                self.filmid_by_key[title] = filmid
                 self.filmid_by_key[self._filmkey(title, url)] = filmid
         except OSError:
             pass
@@ -384,7 +383,8 @@ class FestivalData:
     def write_screenings(self):
         public_screenings = []
         if len(self.screenings):
-            public_screenings = [s for s in self.screenings if s.audience == "publiek" and s.combination_program is None]
+            # public_screenings = [s for s in self.screenings if s.audience == "publiek" and s.combination_program is None]
+            public_screenings = [s for s in self.screenings if s.audience == "publiek"]
             with open(self.screenings_file, 'w') as f:
                 f.write(self.screenings[0].screening_repr_csv_head())
                 for screening in public_screenings:

--- a/PresentScreenings/AppDelegate.cs
+++ b/PresentScreenings/AppDelegate.cs
@@ -38,8 +38,8 @@ namespace PresentScreenings.TableView
         public AppDelegate()
 		{
             // Preferences.
-            Festival = "IDFA";
-            FestivalYear = "2020";
+            Festival = "IFFR";
+            FestivalYear = "2021";
             Screening.TravelTime = new TimeSpan(0, 30, 0);
             FilmRatingDialogController.OnlyFilmsWithScreenings = false;
             FilmRatingDialogController.MinimalDuration = new TimeSpan(0, 35, 0);

--- a/PresentScreenings/Controllers/ViewController.cs
+++ b/PresentScreenings/Controllers/ViewController.cs
@@ -106,7 +106,7 @@ namespace PresentScreenings.TableView
         public override void ViewDidAppear()
         {
             base.ViewDidAppear();
-            this.View.Window.Title = $"{AppDelegate.Festival} {AppDelegate.FestivalYear}";
+            View.Window.Title = $"{AppDelegate.Festival} {AppDelegate.FestivalYear}";
         }
 
         public override void PrepareForSegue(NSStoryboardSegue segue, NSObject sender)

--- a/PresentScreenings/Entities/FilmInfo.cs
+++ b/PresentScreenings/Entities/FilmInfo.cs
@@ -9,16 +9,19 @@ namespace PresentScreenings.TableView
 {
     public class FilmInfo
     {
-        #region Properties
-        public int FilmId { get; }
-        public string FilmDescription { get; private set; }
-        public string FilmArticle { get; private set; }
+        #region Public Structures.
         public struct ScreenedFilm
         {
             public int ScreenedFilmId;
             public string Title;
             public string Description;
         }
+        #endregion
+
+        #region Properties
+        public int FilmId { get; }
+        public string FilmDescription { get; private set; }
+        public string FilmArticle { get; private set; }
         public List<ScreenedFilm> ScreenedFilms { get; private set; }
         public WebUtility.MediumCategory MediumCategory => ViewController.GetFilmById(FilmId).Category;
         public string Url => ViewController.GetFilmById(FilmId).Url;
@@ -61,7 +64,8 @@ namespace PresentScreenings.TableView
                     string titleText = $"{screenedFilm.Title} ({film.MinutesString}) - {film.MaxRating}";
                     return titleText + Environment.NewLine + WebUtility.HtmlToText(screenedFilm.Description);
                 }
-                builder.AppendLine(Environment.NewLine + "Screened films");
+                string header = isCombinationProgram() ? "Screened films" : "Also screened";
+                builder.AppendLine(Environment.NewLine + header);
                 var space = Environment.NewLine + Environment.NewLine;
                 builder.AppendLine(string.Join(space, ScreenedFilms.Select(f => ScreenedFilmText(f))));
             }
@@ -159,6 +163,11 @@ namespace PresentScreenings.TableView
             {
                 throw new IllegalFilmInfoCategoryException($"'{name}' is not a valid FilmInfoCategory");
             }
+        }
+
+        private bool isCombinationProgram()
+        {
+            return MediumCategory == WebUtility.MediumCategory.CombinedProgrammes;
         }
         #endregion
     }


### PR DESCRIPTION
FilmFestivalLoader/IDFA/Movies To IDFA Agenda2020.scpt:
As always

FilmFestivalLoader/IFFR/parse_iffr_html.py:
Catch some more data abnormalies.

FilmFestivalLoader/Shared/planner_interface.py:
Support combination program film ID in screenings.

PresentScreenings/AppDelegate.cs:
Switch to IFFR 2021

PresentScreenings/Controllers/ViewController.cs:
Remove sperfluous this.

PresentScreenings/Entities/FilmInfo.cs:
Support "also screened" chapter in film info.