### PR TITLE
Generate Display Screens for OnLine screenings

### DIFF
--- a/PresentScreenings/Controllers/ViewController.cs
+++ b/PresentScreenings/Controllers/ViewController.cs
@@ -654,6 +654,7 @@ namespace PresentScreenings.TableView
             {
                 onDemandScreening.MoveStartTime(GetSpanToFit(onDemandScreening, forward));
                 Plan.InitializeDays();
+                UpdateAttendanceStatus(onDemandScreening);
                 SetCurrScreening(onDemandScreening);
             }
         }
@@ -668,6 +669,7 @@ namespace PresentScreenings.TableView
                 onDemandScreening.MoveStartTime(span);
                 Plan.InitializeDays();
                 GoToDay(onDemandScreening.StartTime.Date);
+                UpdateAttendanceStatus(onDemandScreening);
                 SetCurrScreening(onDemandScreening);
             }
         }

--- a/PresentScreenings/Entities/OnDemandScreening.cs
+++ b/PresentScreenings/Entities/OnDemandScreening.cs
@@ -2,12 +2,11 @@
 
 namespace PresentScreenings.TableView
 {
-    public class OnDemandScreening : Screening
+    public class OnDemandScreening : OnLineScreening
     {
         #region Private Variables
         private const string _expireTimeFormat = "ddd d-M HH:mm";
         private TimeSpan _duration;
-        private Screen _displayScreen;
         #endregion
 
         #region Properties
@@ -31,21 +30,10 @@ namespace PresentScreenings.TableView
             // Assign other properties.
             EndTime = StartTime + Film.Duration;
             _duration = EndTime - StartTime;
-            DisplayScreen = Screen;
         }
         #endregion
 
         #region Override Methods
-        protected override Screen GetDisplayScreen()
-        {
-            return _displayScreen;
-        }
-
-        protected override void SetDisplayScreen(Screen screen)
-        {
-            _displayScreen = screen;
-        }
-
         public override string ToFilmScreeningLabelString()
         {
             return $"{DayString(StartTime)} {Screen} {StartTime.ToString(_timeFormat)} {DateTimeString(WindowStartTime)}-{DateTimeString(WindowEndTime)} {ExtraTimeSymbolsString()} {ShortAttendingFriendsString()}{ScreeningTitleIfDifferent()}";

--- a/PresentScreenings/Entities/OnLineScreening.cs
+++ b/PresentScreenings/Entities/OnLineScreening.cs
@@ -1,0 +1,29 @@
+﻿using System;
+namespace PresentScreenings.TableView
+{
+    public class OnLineScreening : Screening
+    {
+        #region Private Variables
+        protected Screen _displayScreen;
+        #endregion
+
+        #region Constructors
+        public OnLineScreening(string screeningText) : base(screeningText)
+        {
+            DisplayScreen = Screen;
+        }
+        #endregion
+
+        #region Override Methods
+        protected override Screen GetDisplayScreen()
+        {
+            return _displayScreen;
+        }
+
+        protected override void SetDisplayScreen(Screen screen)
+        {
+            _displayScreen = screen;
+        }
+        #endregion
+    }
+}

--- a/PresentScreenings/Entities/ScreeningsPlan.cs
+++ b/PresentScreenings/Entities/ScreeningsPlan.cs
@@ -308,7 +308,7 @@ namespace PresentScreenings.TableView
             string abbreviation = onLineScreening.Screen.Abbreviation;
             while (abbreviations.Contains(abbreviation))
             {
-                abbreviation = nextAbbreviation(abbreviation);
+                abbreviation = NextAbbreviation(abbreviation);
             }
 
             // Create a new screen with the new screen abbreviation if none already exists.
@@ -329,7 +329,7 @@ namespace PresentScreenings.TableView
             _currScreenScreeningNumber = 0;
         }
 
-        string nextAbbreviation(string currAbbreviation)
+        string NextAbbreviation(string currAbbreviation)
         {
             Match match = _screenRegex.Match(currAbbreviation);
             if (match != null)

--- a/PresentScreenings/Entities/ScreeningsPlan.cs
+++ b/PresentScreenings/Entities/ScreeningsPlan.cs
@@ -96,7 +96,7 @@ namespace PresentScreenings.TableView
             foreach (Screening screening in Screenings)
             {
                 // Initialialize on-demand features when applicable.
-                InitializeOnDemandScreening(screening);
+                InitializeOnLineScreening(screening);
 
                 // Initialize day lists when a new day is encountered.
                 DateTime day = screening.StartDate;
@@ -227,24 +227,37 @@ namespace PresentScreenings.TableView
         #region Private methods
         private Screening PickScreening(string line)
         {
+            // Parse the screen form the input line.
             string[] fields = line.Split(';');
             string screenString = fields[Screening.IndexByName["Screen"]];
             Screen screen = Screens
                 .Where(s => s.Abbreviation == screenString)
                 .First();
-            return screen.Type == Screen.ScreenType.OnDemand ? new OnDemandScreening(line) : new Screening(line);
+
+            // Return the Screening or subclass, dependant of the screen type.
+            switch (screen.Type)
+            {
+                case Screen.ScreenType.OnLine:
+                    return new OnLineScreening(line);
+                case Screen.ScreenType.OnDemand:
+                    return new OnDemandScreening(line);
+                default:
+                    return new Screening(line);
+            }
         }
 
         private void InitializeDisplayScreenByAbbreviation()
         {
             _displayScreenByAbbreviation = new Dictionary<string, Screen> { };
-            foreach (var screen in Screens.Where(s => s.Type == Screen.ScreenType.OnDemand))
+            var onlineScreens = Screens
+                .Where(s => s.Type == Screen.ScreenType.OnLine || s.Type == Screen.ScreenType.OnDemand);
+            foreach (var screen in onlineScreens)
             {
                 _displayScreenByAbbreviation.Add(screen.Abbreviation, screen);
             }
         }
 
-        private void InitializeOnDemandScreening(Screening screening)
+        private void InitializeOnLineScreening(Screening screening)
         {
             if (screening is OnDemandScreening onDemandScreening)
             {
@@ -267,37 +280,45 @@ namespace PresentScreenings.TableView
                 {
                     onDemandScreening.MoveStartTime(ViewController.EarliestTime - timeOfDay);
                 }
-
-                // Fix overlapping on-line and on-demand screenings on the smae "screen".
-                FixOverlappingScreenings(onDemandScreening);
+            }
+            if (screening is OnLineScreening onLineScreening)
+            {
+                // Fix overlapping on-line and on-demand screenings on the same "screen".
+                FixOverlappingScreenings(onLineScreening);
             }
         }
 
-        private void FixOverlappingScreenings(OnDemandScreening onDemandScreening)
+        private void FixOverlappingScreenings(OnLineScreening onLineScreening)
         {
+            // Establish whether there are coinciding screenings.
             var overlappers = Screenings
-                .Where(s => s != onDemandScreening && s.Overlaps(onDemandScreening, true) && s is OnDemandScreening);
+                .Where(s => s != onLineScreening && s.Overlaps(onLineScreening, true) && (s is OnLineScreening));
             var coinciders = overlappers
-                .Where(s => s.Screen == onDemandScreening.Screen);
+                .Where(s => s.Screen == onLineScreening.Screen);
             if (coinciders.Count() == 0)
             {
-                onDemandScreening.DisplayScreen = onDemandScreening.Screen;
+                onLineScreening.DisplayScreen = onLineScreening.Screen;
                 return;
             }
+
+            // Gererate a screen abbreviation different from all overlapping screenings.
             var abbreviations = overlappers
                 .Select(s => s.DisplayScreen.Abbreviation)
                 .Distinct();
-
-            string abbreviation = onDemandScreening.Screen.Abbreviation;
+            string abbreviation = onLineScreening.Screen.Abbreviation;
             while (abbreviations.Contains(abbreviation))
             {
                 abbreviation = nextAbbreviation(abbreviation);
             }
+
+            // Create a new screen with the new screen abbreviation if none already exists.
             if (!_displayScreenByAbbreviation.ContainsKey(abbreviation))
             {
-                _displayScreenByAbbreviation.Add(abbreviation, new Screen(onDemandScreening.DisplayScreen, abbreviation));
+                _displayScreenByAbbreviation.Add(abbreviation, new Screen(onLineScreening.Screen, abbreviation));
             }
-            onDemandScreening.DisplayScreen = _displayScreenByAbbreviation[abbreviation];
+
+            // Assign the screen with the new screen abbreviation to the Display Screen.
+            onLineScreening.DisplayScreen = _displayScreenByAbbreviation[abbreviation];
         }
 
         private void SetDay(DateTime day)

--- a/PresentScreenings/PresentScreenings.csproj
+++ b/PresentScreenings/PresentScreenings.csproj
@@ -174,6 +174,7 @@
     </Compile>
     <Compile Include="Entities\FilmFanAvailability.cs" />
     <Compile Include="Entities\OnDemandScreening.cs" />
+    <Compile Include="Entities\OnLineScreening.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Main.storyboard" />


### PR DESCRIPTION
PresentScreenings/PresentScreenings.csproj:
PresentScreenings/Entities/OnLineScreening.cs:
Implement OnLine screenings using a new class.

FilmFestivalLoader/IFFR/parse_iffr_html.py:
Drop functionality to create Display Screens.

FilmFestivalLoader/Shared/planner_interface.py:
Drop support for generating Display Screens.
Improve screen type checks.

PresentScreenings/Controllers/ViewController.cs:
Fix regression in attendace status updates.

PresentScreenings/Entities/OnDemandScreening.cs:
Move Display Screen functionality to OnLineScreening.

PresentScreenings/Entities/ScreeningsPlan.cs:
Generate Display Screens for OnLine screenings.