### PR TITLE
Fix bug so Unplanned Films dialog will close

### DIFF
--- a/PresentScreenings/AppDelegate.cs
+++ b/PresentScreenings/AppDelegate.cs
@@ -196,8 +196,7 @@ namespace PresentScreenings.TableView
             Controller.SetPreviousScreening();
         }
 
-        [Action("NavigateFilmScreening:")]
-        internal void NavigateFilmScreening(NSObject sender)
+        internal void NavigateFilmScreening(Screening screening)
         {
             if (FilmsDialogController != null)
             {
@@ -207,8 +206,14 @@ namespace PresentScreenings.TableView
             {
                 AnalyserDialogController.CloseDialog();
             }
-            var screening = ScreeningMenuDelegate.FilmScreening(((NSMenuItem)sender).Title);
             Controller.GoToScreening(screening);
+        }
+
+        [Action("NavigateFilmScreening:")]
+        internal void NavigateFilmScreening(NSObject sender)
+        {
+            var screening = ScreeningMenuDelegate.FilmScreening(((NSMenuItem)sender).Title);
+            NavigateFilmScreening(screening);
         }
 
         [Action("ToggleAttendance:")]

--- a/PresentScreenings/Controllers/AnalyserDialogController.cs
+++ b/PresentScreenings/Controllers/AnalyserDialogController.cs
@@ -14,11 +14,11 @@ namespace PresentScreenings.TableView
     /// overlapping screenings.
     /// </summary>
 
-    public partial class AnalyserDialogController : GoToScreeningDialog, IScreeningProvider
+    public partial class AnalyserDialogController : NSViewController, IScreeningProvider
 	{
         #region Private Variables
-        ViewController _presentor;
-        FilmOutlineDataSource _dataSource;
+        private ViewController _presentor;
+        private FilmOutlineDataSource _dataSource;
         #endregion
 
         #region Constructors
@@ -28,7 +28,7 @@ namespace PresentScreenings.TableView
         #endregion
 
         #region Application Access
-        static AppDelegate _app => (AppDelegate)NSApplication.SharedApplication.Delegate;
+        private static AppDelegate App => (AppDelegate)NSApplication.SharedApplication.Delegate;
         #endregion
 
         #region Properties
@@ -37,7 +37,7 @@ namespace PresentScreenings.TableView
 
         #region Interface Implementations
         Film IScreeningProvider.CurrentFilm => GetSelectedFilm();
-        Screening IScreeningProvider.CurrentScreening => _app.Controller.CurrentScreening;
+        Screening IScreeningProvider.CurrentScreening => App.Controller.CurrentScreening;
         List<Screening> IScreeningProvider.Screenings => GetFilmScreenings();
         #endregion
 
@@ -47,13 +47,13 @@ namespace PresentScreenings.TableView
             base.ViewDidLoad();
 
             // Initialize the presentor.
-            _presentor = _app.Controller;
+            _presentor = App.Controller;
 
             // Tell the app delegate we're alive.
-            _app.AnalyserDialogController = this;
+            App.AnalyserDialogController = this;
 
             // Set the GoToScreening function for screenings.
-            Screening.GoToScreening = GoToScreening;
+            Screening.GoToScreening = App.NavigateFilmScreening;
 
             // Create data source and populate.
             _dataSource = new FilmOutlineDataSource();
@@ -102,20 +102,10 @@ namespace PresentScreenings.TableView
             base.ViewWillDisappear();
 
             // Tell the app delegate we're gone.
-            _app.AnalyserDialogController = null;
+            App.AnalyserDialogController = null;
 
             // Tell the main view controller we're gone.
             _presentor.RunningPopupsCount--;
-        }
-
-        public override void GoToScreening(Screening screening)
-        {
-            _presentor.GoToScreening(screening);
-
-            // Commented out as a work-around to prevent:
-            // *** Terminating app due to uncaught exception 'NSInternalInconsistencyException',
-            // reason: 'dismissViewController:: Error: maybe this view controller was not presented?'
-            //CloseDialog();
         }
         #endregion
 
@@ -183,9 +173,6 @@ namespace PresentScreenings.TableView
         {
             _presentor.DismissViewController(this);
         }
-        #endregion
-
-        #region Private Methods
         #endregion
     }
 }

--- a/PresentScreenings/Controls/FilmScreeningControl.cs
+++ b/PresentScreenings/Controls/FilmScreeningControl.cs
@@ -87,7 +87,13 @@ namespace PresentScreenings.TableView
                 // Draw a frame if something's wrong with the tickets
                 if (ScreeningInfo.TicketStatusNeedsAttention(_screening))
                 {
-					ColorView.DrawTicketAvalabilityFrame(g, _screening, Frame);
+					ColorView.DrawTicketAvalabilityFrame(g, _screening, Frame.Width);
+                }
+
+                // Draw a progress bar if the screening is on-demand.
+                if (_screening is OnDemandScreening onDemandScreening)
+                {
+                    ColorView.DrawOnDemandAvailabilityStatus(g, onDemandScreening, Frame.Width, Selected);
                 }
 
                 // Draw Sold Out Symbol

--- a/PresentScreenings/Controls/ScreeningControl.cs
+++ b/PresentScreenings/Controls/ScreeningControl.cs
@@ -125,7 +125,7 @@ namespace PresentScreenings.TableView
                 // Draw a progress bar if the screening is on-demand.
                 if (Screening is OnDemandScreening onDemandScreening)
                 {
-                    ColorView.DrawOnDemandAvailabilityStatus(context, onDemandScreening, clickableRect, Selected);
+                    ColorView.DrawOnDemandAvailabilityStatus(context, onDemandScreening, side, Selected);
                 }
 
                 // Draw Sold Out symbol.

--- a/PresentScreenings/Entities/Screening.cs
+++ b/PresentScreenings/Entities/Screening.cs
@@ -245,7 +245,7 @@ namespace PresentScreenings.TableView
             var infoButton = new FilmScreeningControl(rect, this);
             infoButton.ReDraw();
             infoButton.ScreeningInfoAsked += (sender, e) => GoToScreening(this);
-            infoButton.Selected = false;
+            infoButton.Selected = FilmOutlineLevel.ScreeningIsSelected(this);
             view.AddSubview(infoButton);
         }
 

--- a/PresentScreenings/Table Classes/FilmOutlineLevel.cs
+++ b/PresentScreenings/Table Classes/FilmOutlineLevel.cs
@@ -76,7 +76,7 @@ namespace PresentScreenings.TableView
                 var infoButton = new FilmScreeningControl(view.Frame, screening);
                 infoButton.ReDraw();
                 infoButton.ScreeningInfoAsked += (sender, e) => FilmOutlineLevel.GoToScreening(screening);
-                infoButton.Selected = false;
+                infoButton.Selected = ScreeningIsSelected(screening);
                 view.AddSubview(infoButton);
             }
         }
@@ -91,6 +91,14 @@ namespace PresentScreenings.TableView
                 view.StringValue += "  " + FilmInfo.InfoString(((Screening)_filmOutlinable).Film);
                 view.LineBreakMode = NSLineBreakMode.TruncatingTail;
             }
+        }
+        #endregion
+
+        #region Public Methods
+        public static bool ScreeningIsSelected(Screening screening)
+        {
+            AppDelegate app = (AppDelegate)NSApplication.SharedApplication.Delegate;
+            return app.Controller.CurrentScreening == screening;
         }
         #endregion
     }

--- a/PresentScreenings/Views/ColorView.cs
+++ b/PresentScreenings/Views/ColorView.cs
@@ -145,14 +145,14 @@ namespace PresentScreenings.TableView
             g.DrawPath(CGPathDrawingMode.Stroke);
         }
 
-        public static void DrawTicketAvalabilityFrame(CGContext g, Screening screening, CGRect rect)
+        public static void DrawTicketAvalabilityFrame(CGContext g, Screening screening, nfloat side)
         {
             g.SetLineWidth(2);
             SetTicketsStatusColor(screening, g);
             var rectPath = new CGPath();
             nfloat org = 1;
-            nfloat x = rect.Width - 2 * org;
-            nfloat y = rect.Height - 2 * org;
+            nfloat x = side - 2 * org;
+            nfloat y = side - 2 * org;
             rectPath.AddLines(new CGPoint[]{
                 new CGPoint(org, y),
                 new CGPoint(x, y),
@@ -164,20 +164,15 @@ namespace PresentScreenings.TableView
             g.DrawPath(CGPathDrawingMode.Stroke);
         }
 
-        public static void DrawTicketAvalabilityFrame(CGContext g, Screening screening, nfloat side)
-        {
-            DrawTicketAvalabilityFrame(g, screening, new CGRect(0, 0, side, side));
-        }
-
-        public static void DrawOnDemandAvailabilityStatus(CGContext context, OnDemandScreening screening, CGRect rect, bool selected)
+        public static void DrawOnDemandAvailabilityStatus(CGContext context, OnDemandScreening screening, nfloat side, bool selected)
         {
             // Establish some base dimensions.
             const int maxDaysInRuler = 5;
             const int margin = 2;
-            nfloat w = rect.Width - 2 * margin;
-            nfloat h = rect.Height - 2 * margin;
-            nfloat x = rect.X + margin;
-            nfloat y = rect.Y + margin;
+            nfloat w = side - 2 * margin;
+            nfloat h = side - 2 * margin;
+            nfloat x = margin;
+            nfloat y = margin;
             var windowSeconds = (screening.WindowEndTime - screening.WindowStartTime).TotalSeconds;
             var passedSeconds = (screening.StartTime - screening.WindowStartTime).TotalSeconds;
             nfloat wPassed = w * (nfloat)passedSeconds / (nfloat)windowSeconds;


### PR DESCRIPTION
PresentScreenings/AppDelegate.cs:
Facilitate navigating to a screening based on a screening only.

PresentScreenings/Controllers/AnalyserDialogController.cs:
Stop inheriting from GoToScreeningDialog.
Navigate to a screening via a call to an App Delegate member method.

PresentScreenings/Entities/Screening.cs, PresentScreenings/Table Classes/FilmOutlineLevel.cs:
Indicate if the screening assiociated with an info button is selected by coloring.