### PR TITLE
Empty the outlinables tree in the Analyzer

### DIFF
--- a/PresentScreenings/AppDelegate.cs
+++ b/PresentScreenings/AppDelegate.cs
@@ -26,13 +26,13 @@ namespace PresentScreenings.TableView
 
         #region Properties
         public ViewController Controller { get; set; } = null;
-        public FilmRatingDialogController FilmsDialogController { get; set; }
         public AnalyserDialogController AnalyserDialogController { get; set; }
-        public CombineTitlesSheetController CombineTitleController { get; set; }
-        public UncombineTitlesSheetController UncombineTitleController;
-        public FilmInfoDialogController filmInfoController;
-        public PlannerDialogController PlannerDialogController;
         public AvailabilityDialogControler AvailabilityDialogControler { get; set; }
+        public CombineTitlesSheetController CombineTitleController { get; set; }
+        public FilmInfoDialogController FilmInfoController { get; set; }
+        public FilmRatingDialogController FilmsDialogController { get; set; }
+        public PlannerDialogController PlannerDialogController { get; set; }
+        public UncombineTitlesSheetController UncombineTitleController { get; set; }
         public ScreeningMenuDelegate ScreeningMenuDelegate => (ScreeningMenuDelegate)_screeningMenu.Delegate;
         public NSMenuItem ToggleTypeMatchMenuItem => _toggleTypeMatchMethod;
         #endregion

--- a/PresentScreenings/Controllers/AnalyserDialogController.cs
+++ b/PresentScreenings/Controllers/AnalyserDialogController.cs
@@ -21,18 +21,14 @@ namespace PresentScreenings.TableView
         private FilmOutlineDataSource _dataSource;
         #endregion
 
+        #region Properties
+        private static AppDelegate App => (AppDelegate)NSApplication.SharedApplication.Delegate;
+        #endregion
+
         #region Constructors
         public AnalyserDialogController (IntPtr handle) : base (handle)
 		{
         }
-        #endregion
-
-        #region Application Access
-        private static AppDelegate App => (AppDelegate)NSApplication.SharedApplication.Delegate;
-        #endregion
-
-        #region Properties
-        public NSOutlineView FilmOutlineView => _filmOutlineView;
         #endregion
 
         #region Interface Implementations
@@ -164,13 +160,27 @@ namespace PresentScreenings.TableView
             return new List<Screening> { };
         }
 
-        public static bool FilterHighRatedFilms(Film film)
+        public bool FilterHighRatedFilms(Film film)
         {
             return film.MaxRating.IsGreaterOrEqual(FilmRating.LowestSuperRating);
         }
 
+        public static void CleanupOutlinables(List<IFilmOutlinable> filmOutlinables)
+        {
+            foreach (var filmOutlinable in filmOutlinables)
+            {
+                filmOutlinable.Cleanup();
+            }
+            var count = filmOutlinables.Count;
+            if (count > 0)
+            {
+                filmOutlinables.RemoveRange(0, count);
+            }
+        }
+
         public void CloseDialog()
         {
+            CleanupOutlinables(_dataSource.FilmOutlinables);
             _presentor.DismissViewController(this);
         }
         #endregion

--- a/PresentScreenings/Controllers/FilmInfoDialogController.cs
+++ b/PresentScreenings/Controllers/FilmInfoDialogController.cs
@@ -66,7 +66,7 @@ namespace PresentScreenings.TableView
             base.ViewWillAppear();
 
             // Tell the app delegate that we're alive.
-            App.filmInfoController = this;
+            App.FilmInfoController = this;
 
             // Get the selected film.
             _film = ((IScreeningProvider)Presentor).CurrentFilm;
@@ -91,7 +91,7 @@ namespace PresentScreenings.TableView
             base.ViewWillDisappear();
 
             // Tell the app delegate that we're gone.
-            App.filmInfoController = null;
+            App.FilmInfoController = null;
         }
         #endregion
 

--- a/PresentScreenings/Controllers/ScreeningDialogController.cs
+++ b/PresentScreenings/Controllers/ScreeningDialogController.cs
@@ -65,6 +65,7 @@ namespace PresentScreenings.TableView
             base.ViewWillAppear();
 
             // Tell the presentor we're alive.
+            _presentor.ScreeningInfoDialog = this;
             _presentor.RunningPopupsCount += 1;
 
             // Initialize the list of screenings.
@@ -85,6 +86,10 @@ namespace PresentScreenings.TableView
         {
             // Tell the presentor we're gone.
             _presentor.RunningPopupsCount--;
+            if (_presentor.RunningPopupsCount == 0)
+            {
+                _presentor.ScreeningInfoDialog = null;
+            }
         }
 
         public override void PrepareForSegue(NSStoryboardSegue segue, NSObject sender)
@@ -222,15 +227,6 @@ namespace PresentScreenings.TableView
             _sampleSubView = scrollView;
         }
 
-        private void UpdateAttendances()
-        {
-            _labelPresent.StringValue = _screening.AttendeesString();
-            _presentor.UpdateAttendanceStatus(_screening);
-            _presentor.ReloadScreeningsView();
-            UpdateScreeningControls();
-            _screeningInfoControl.ReDraw();
-        }
-
         private void CloseDialog()
         {
             _presentor.DismissViewController(this);
@@ -307,6 +303,15 @@ namespace PresentScreenings.TableView
             UpdateAttendances();
             var attendanceState = AttendanceCheckbox.GetAttendanceState(_screening.FilmFanAttends(filmFan));
             _attendanceCheckboxByFilmFan[filmFan].State = attendanceState;
+        }
+
+        public void UpdateAttendances()
+        {
+            _labelPresent.StringValue = _screening.AttendeesString();
+            _presentor.UpdateAttendanceStatus(_screening);
+            _presentor.ReloadScreeningsView();
+            UpdateScreeningControls();
+            _screeningInfoControl.ReDraw();
         }
         #endregion
 

--- a/PresentScreenings/Controllers/ViewController.cs
+++ b/PresentScreenings/Controllers/ViewController.cs
@@ -28,6 +28,7 @@ namespace PresentScreenings.TableView
         #region Properties
         public ScreeningsPlan Plan => _plan;
         public NSTableView TableView => ScreeningsTable;
+        internal ScreeningDialogController ScreeningInfoDialog { get; set; }
         internal int RunningPopupsCount { get; set; } = 0;
         public static TimeSpan DaySpan => new TimeSpan(24, 0, 0);
         public static TimeSpan EarliestTime => new TimeSpan(ScreeningsTableView.FirstDisplayedHour, 0, 0);
@@ -272,10 +273,6 @@ namespace PresentScreenings.TableView
         public void ReloadScreeningsView()
         {
             TableView.ReloadData();
-            if (App.AnalyserDialogController != null)
-            {
-                App.AnalyserDialogController.FilmOutlineView.ReloadData();
-            }
         }
 
         public void AddScreeningControl(Screening screening, ScreeningControl control)
@@ -586,6 +583,7 @@ namespace PresentScreenings.TableView
         {
             _plan.CurrDay = day;
             DisplayScreeningsView();
+            ScreeningInfoDialog?.UpdateAttendances();
         }
 
         public void SetNextDay(int days)
@@ -655,6 +653,7 @@ namespace PresentScreenings.TableView
                 onDemandScreening.MoveStartTime(GetSpanToFit(onDemandScreening, forward));
                 Plan.InitializeDays();
                 UpdateAttendanceStatus(onDemandScreening);
+                ScreeningInfoDialog?.UpdateAttendances();
                 SetCurrScreening(onDemandScreening);
             }
         }

--- a/PresentScreenings/Entities/Film.cs
+++ b/PresentScreenings/Entities/Film.cs
@@ -135,6 +135,11 @@ namespace PresentScreenings.TableView
             view.BackgroundColor = NSColor.Clear;
             view.TextColor = NSColor.Text;
         }
+
+        void IFilmOutlinable.Cleanup()
+        {
+            AnalyserDialogController.CleanupOutlinables(FilmOutlinables);
+        }
         #endregion
 
         #region Public Methods

--- a/PresentScreenings/Entities/Screening.cs
+++ b/PresentScreenings/Entities/Screening.cs
@@ -260,6 +260,11 @@ namespace PresentScreenings.TableView
             view.StringValue = ScreeningStringForLabel(true);
             view.LineBreakMode = NSLineBreakMode.TruncatingTail;
         }
+
+        void IFilmOutlinable.Cleanup()
+        {
+            AnalyserDialogController.CleanupOutlinables(FilmOutlinables);
+        }
         #endregion
 
         #region Public Methods

--- a/PresentScreenings/Entities/ScreeningsPlan.cs
+++ b/PresentScreenings/Entities/ScreeningsPlan.cs
@@ -235,15 +235,9 @@ namespace PresentScreenings.TableView
                 .First();
 
             // Return the Screening or subclass, dependant of the screen type.
-            switch (screen.Type)
-            {
-                case Screen.ScreenType.OnLine:
-                    return new OnLineScreening(line);
-                case Screen.ScreenType.OnDemand:
-                    return new OnDemandScreening(line);
-                default:
-                    return new Screening(line);
-            }
+            return screen.Type == Screen.ScreenType.OnLine ? new OnLineScreening(line)
+                : screen.Type == Screen.ScreenType.OnDemand ? new OnDemandScreening(line)
+                : new Screening(line);
         }
 
         private void InitializeDisplayScreenByAbbreviation()

--- a/PresentScreenings/Interfaces/IFilmOutlinable.cs
+++ b/PresentScreenings/Interfaces/IFilmOutlinable.cs
@@ -15,6 +15,7 @@ namespace PresentScreenings.TableView
         void SetRating(NSTextField view);
         void SetGo(NSView view);
         void SetInfo(NSTextField view);
+        void Cleanup();
         #endregion
     }
 }

--- a/PresentScreenings/Menu Delegates/FilmsMenuDelegate.cs
+++ b/PresentScreenings/Menu Delegates/FilmsMenuDelegate.cs
@@ -36,7 +36,7 @@ namespace PresentScreenings.TableView
             foreach (NSMenuItem item in menu.Items)
             {
                 // If one of the film dialogs is active, all menu items must be inactive.
-                if (_app.CombineTitleController != null || _app.UncombineTitleController != null || _app.filmInfoController != null)
+                if (_app.CombineTitleController != null || _app.UncombineTitleController != null || _app.FilmInfoController != null)
                 {
                     item.Enabled = false;
                     continue;

--- a/PresentScreenings/Menu Delegates/ScreeningMenuDelegate.cs
+++ b/PresentScreenings/Menu Delegates/ScreeningMenuDelegate.cs
@@ -292,7 +292,7 @@ namespace PresentScreenings.TableView
                     item.KeyEquivalentModifierMask = mask;
                 }
                 menu.AddItem(item);
-                bool enabled = (AnalyserViewRunning() || screening != Screening);
+                bool enabled = AnalyserViewRunning() || screening != Screening;
                 _FilmScreeningEnabledByTag.Add(item.Tag, enabled);
                 _filmScreeningByMenuItemTitle.Add(itemTitle, screening);
             }

--- a/PresentScreenings/Table Classes/FilmOutlineDataSource.cs
+++ b/PresentScreenings/Table Classes/FilmOutlineDataSource.cs
@@ -28,7 +28,6 @@ namespace PresentScreenings.TableView
             {
                 return ((IFilmOutlinable)item).FilmOutlinables.Count;
             }
-
         }
 
         public override NSObject GetChild(NSOutlineView outlineView, nint childIndex, NSObject item)

--- a/PresentScreenings/Table Classes/FilmOutlineLevel.cs
+++ b/PresentScreenings/Table Classes/FilmOutlineLevel.cs
@@ -92,6 +92,11 @@ namespace PresentScreenings.TableView
                 view.LineBreakMode = NSLineBreakMode.TruncatingTail;
             }
         }
+
+        void IFilmOutlinable.Cleanup()
+        {
+            AnalyserDialogController.CleanupOutlinables(FilmOutlinables);
+        }
         #endregion
 
         #region Public Methods


### PR DESCRIPTION
PresentScreenings/Controllers/ViewController.cs:
Support access to the screening info dialog from the screenings dialog.
Clean-up unused code.
Update screening info dialog when moving a screening from it.

PresentScreenings/Controllers/AnalyserDialogController.cs:
Cleanup unused property.
Support emptying the outlinables tree.

PresentScreenings/Entities/Film.cs, PresentScreenings/Entities/Screening.cs, PresentScreenings/Interfaces/IFilmOutlinable.cs, PresentScreenings/Table Classes/FilmOutlineLevel.cs:
PresentScreenings/Controllers/AnalyserDialogController.cs

PresentScreenings/AppDelegate.cs:
Order properties that represent a dialog.

PresentScreenings/Menu Delegates/FilmsMenuDelegate.cs, PresentScreenings/Controllers/FilmInfoDialogController.cs:
Fix camelCase name.

PresentScreenings/Controllers/ScreeningDialogController.cs:
Support access to the screening info dialog from the screenings dialog.

PresentScreenings/Entities/ScreeningsPlan.cs:
Save some lines of code.

PresentScreenings/Menu Delegates/ScreeningMenuDelegate.cs:
Fix faulty enebaled menu items.

PresentScreenings/Table Classes/FilmOutlineDataSource.cs:
Delete superfluous empty line.