### PR TITLE
Use separate ID for original  and combined titles

### DIFF
--- a/PresentScreenings/Controllers/AvailabilityDialogControler.cs
+++ b/PresentScreenings/Controllers/AvailabilityDialogControler.cs
@@ -207,7 +207,7 @@ namespace PresentScreenings.TableView
             var scrollerHeight = _yCurr - _yControlsMargin - _controlHeight - _yBetweenControls;
             _yCurr -= scrollerHeight;
             var scrollerFrame = new CGRect(_xMargin, _yCurr, documentWidth, scrollerHeight);
-            var scrollerView = ControlsFactory.NewStandardScrollView(scrollerFrame, documentView);
+            var scrollerView = ControlsFactory.NewStandardScrollView(scrollerFrame, documentView, true);
             View.AddSubview(scrollerView);
 
             // Populate the document view.

--- a/PresentScreenings/Controllers/ScreeningDialogController.cs
+++ b/PresentScreenings/Controllers/ScreeningDialogController.cs
@@ -214,7 +214,7 @@ namespace PresentScreenings.TableView
             var scrollViewHeight = _yCurr - _yBetweenViews - _buttonHeight - _yMargin;
             _yCurr -= scrollViewHeight;
             var scrollViewFrame = new CGRect(_xMargin, _yCurr, contentWidth, scrollViewHeight);
-            var scrollView = ControlsFactory.NewStandardScrollView(scrollViewFrame, screeningsView);
+            var scrollView = ControlsFactory.NewStandardScrollView(scrollViewFrame, screeningsView, true);
             View.AddSubview(scrollView);
 
             // Display the screenings.

--- a/PresentScreenings/Controllers/UncombineTitlesSheetController.cs
+++ b/PresentScreenings/Controllers/UncombineTitlesSheetController.cs
@@ -131,21 +131,17 @@ namespace PresentScreenings.TableView
 
             // Create the window title label.
             _yCurr -= _labelHeight;
-            var titleLabel = new NSTextField(new CGRect(_xMargin, _yCurr, labelWidth, _labelHeight));
-            titleLabel.Editable = false;
+            var titleLabelRect = new CGRect(_xMargin, _yCurr, labelWidth, _labelHeight);
+            var titleLabel = ControlsFactory.NewStandardLabel(titleLabelRect);
             titleLabel.Font = NSFont.BoldSystemFontOfSize(NSFont.SystemFontSize);
-            titleLabel.BackgroundColor = NSColor.WindowBackground;
-            titleLabel.Bordered = false;
             titleLabel.StringValue = "Uncombine film";
             View.AddSubview(titleLabel);
 
             // Create the instruction label.
             _yCurr -= _labelHeight + _yLabelsDistance;
-            var instructionLabel = new NSTextField(new CGRect(_xMargin, _yCurr, labelWidth, _labelHeight));
-            instructionLabel.Editable = false;
+            var instructionLabelRect = new CGRect(_xMargin, _yCurr, labelWidth, _labelHeight);
+            var instructionLabel = ControlsFactory.NewStandardLabel(instructionLabelRect);
             instructionLabel.Font = NSFont.LabelFontOfSize(NSFont.LabelFontSize);
-            instructionLabel.BackgroundColor = NSColor.WindowBackground;
-            instructionLabel.Bordered = false;
             instructionLabel.StringValue = "Create multiple films, one per distinct screening title";
             View.AddSubview(instructionLabel);
 

--- a/PresentScreenings/Controllers/ViewController.cs
+++ b/PresentScreenings/Controllers/ViewController.cs
@@ -331,7 +331,7 @@ namespace PresentScreenings.TableView
 
         public static ScreeningInfo GetScreeningInfo(int filmId, Screen screen, DateTime startTime)
         {
-            var info = ScreeningsPlan.ScreeningInfos.Where(s => s.FilmId == filmId && s.Screen == screen && s.StartTime == startTime).ToList();
+            var info = ScreeningsPlan.ScreeningInfos.Where(s => s.OriginalFilmId == filmId && s.Screen == screen && s.StartTime == startTime).ToList();
             return info.Count > 0 ? info.First() : null;
         }
         #endregion

--- a/PresentScreenings/Entities/ScreeningInfo.cs
+++ b/PresentScreenings/Entities/ScreeningInfo.cs
@@ -48,10 +48,9 @@ namespace PresentScreenings.TableView
         #endregion
 
         #region Properties
-        public int FilmId { get; private set; }
+        public int OriginalFilmId { get; }
         public Screen Screen { get; private set; }
         public DateTime StartTime { get; }
-        public string ScreeningTitle { get; set; }
         public DateTime MovableStartTime { get; set; }
         public DateTime MovableEndTime { get; set; }
         public bool AutomaticallyPlanned { get; set; } = false;
@@ -62,6 +61,7 @@ namespace PresentScreenings.TableView
         #endregion
 
         #region Calculated Properties
+        public int CombinedFilmId { get; set; }
         public static string Me => "Maarten";
         public static List<string> FilmFans => new List<string> { Me, "Adrienne", "Manfred", "Piggel", "Rijk" };
         public static List<string> MyFriends => FilmFans.Skip(1).ToList();
@@ -100,19 +100,19 @@ namespace PresentScreenings.TableView
         {
             // Parse the fields of the input string.
             string[] fields = ScreeningInfoText.Split(';');
-            FilmId = int.Parse(fields[0]);
+            OriginalFilmId = int.Parse(fields[0]);
             string screen = fields[1];
             StartTime = DateTime.Parse(fields[2]);
             MovableStartTime = DateTime.Parse(fields[3]);
             MovableEndTime = DateTime.Parse(fields[4]);
-            ScreeningTitle = fields[5];
+            CombinedFilmId = int.Parse(fields[5]);
             string automaticallyPlanned = fields[6];
             string screeningStatus = fields[7];
             var attendanceStrings = new List<string>(fields[8].Split(','));
             string ticketsBought = fields[9];
             string soldOut = fields[10];
 
-            // Assign members.
+            // Assign properties.
             Screen = ScreeningsPlan.Screens.First(s => s.ToString() == screen);
             AutomaticallyPlanned = StringToBool[automaticallyPlanned];
             Attendees = GetAttendeesFromStrings(attendanceStrings);
@@ -123,10 +123,10 @@ namespace PresentScreenings.TableView
 
         public ScreeningInfo(int filmId, Screen screen, DateTime startTime)
         {
-            FilmId = filmId;
+            OriginalFilmId = filmId;
+            CombinedFilmId = filmId;
             Screen = screen;
             StartTime = startTime;
-            ScreeningTitle = ViewController.GetFilmById(FilmId).Title;
             Attendees = new List<string>{ };
             TicketsBought = false;
             SoldOut = false;
@@ -142,7 +142,7 @@ namespace PresentScreenings.TableView
 
         public override string WriteHeader()
         {
-            string headerFmt = "filmid;screen;starttime;movablestarttime;movableendtime;screeningtitle;autoplanned;blocked;{0};ticketsbought;soldout";
+            string headerFmt = "filmid;screen;starttime;movablestarttime;movableendtime;combinedfilmid;autoplanned;blocked;{0};ticketsbought;soldout";
             return string.Format(headerFmt, FilmFansString());
         }
 
@@ -150,12 +150,12 @@ namespace PresentScreenings.TableView
         {
             string line = string.Join(
                 ';',
-                FilmId,
+                OriginalFilmId,
                 Screen,
                 StartTime.ToString(_dateTimeFormat),
                 MovableStartTime.ToString(_dateTimeFormat),
                 MovableEndTime.ToString(_dateTimeFormat),
-                ScreeningTitle,
+                CombinedFilmId,
                 BoolToString[AutomaticallyPlanned],
                 _stringByScreeningStatus[Status],
                 AttendeesString(),

--- a/PresentScreenings/Main.storyboard
+++ b/PresentScreenings/Main.storyboard
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -667,19 +666,18 @@ DQ
                             <scrollView autohidesScrollers="YES" horizontalLineScroll="40" horizontalPageScroll="10" verticalLineScroll="40" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T19-6q-88n">
                                 <rect key="frame" x="0.0" y="-1" width="1040" height="730"/>
                                 <clipView key="contentView" autoresizesSubviews="NO" id="qL0-te-bse">
-                                    <rect key="frame" x="1" y="0.0" width="1038" height="729"/>
+                                    <rect key="frame" x="1" y="1" width="1038" height="728"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView focusRingType="exterior" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="reverseSequential" selectionHighlightStyle="none" columnReordering="NO" columnResizing="NO" multipleSelection="NO" typeSelect="NO" autosaveName="SavedScreenings.csv" rowHeight="38" headerView="PKT-NF-xHB" viewBased="YES" id="PK9-Du-huX">
-                                            <rect key="frame" x="0.0" y="0.0" width="2602" height="706"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="2611" height="705"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="2"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
                                                 <tableColumn identifier="Screens" width="116" minWidth="51" maxWidth="1000" id="sss-rU-t1T" userLabel="Screens Column">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Screens">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -691,11 +689,11 @@ DQ
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="qN8-hb-2bK">
-                                                            <rect key="frame" x="1" y="1" width="116" height="51"/>
+                                                            <rect key="frame" x="11" y="1" width="121" height="51"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField autoresizesSubviews="NO" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qc3-Uh-Hfb">
-                                                                    <rect key="frame" x="0.0" y="-1248" width="116" height="1299"/>
+                                                                    <rect key="frame" x="0.0" y="-1248" width="121" height="1299"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" focusRingType="none" title="ScreensTableViewCell" drawsBackground="YES" id="Xwj-h1-Glt">
                                                                         <font key="font" metaFont="system"/>
@@ -712,7 +710,6 @@ DQ
                                                 </tableColumn>
                                                 <tableColumn identifier="Screenings" width="2480" minWidth="40" maxWidth="2480" id="Hzd-WA-p3s" userLabel="Screenings Colomn">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Screenings">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -724,11 +721,11 @@ DQ
                                                     <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="ZNb-p1-Gcr">
-                                                            <rect key="frame" x="120" y="1" width="2480" height="51"/>
+                                                            <rect key="frame" x="135" y="1" width="2484" height="51"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField autoresizesSubviews="NO" focusRingType="exterior" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9Xc-63-6WM">
-                                                                    <rect key="frame" x="0.0" y="-1248" width="2480" height="1299"/>
+                                                                    <rect key="frame" x="0.0" y="-1248" width="2484" height="1299"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" allowsUndo="NO" focusRingType="exterior" title="ScreeningsTableViewCell" drawsBackground="YES" id="o0w-we-to7">
                                                                         <font key="font" metaFont="system"/>
@@ -750,16 +747,16 @@ DQ
                                         </tableView>
                                     </subviews>
                                 </clipView>
-                                <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="jsb-Kh-rpm">
+                                <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="jsb-Kh-rpm">
                                     <rect key="frame" x="1" y="713" width="1038" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="Dwc-dJ-kPy">
+                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="Dwc-dJ-kPy">
                                     <rect key="frame" x="224" y="17" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <tableHeaderView key="headerView" id="PKT-NF-xHB">
-                                    <rect key="frame" x="0.0" y="0.0" width="2602" height="23"/>
+                                <tableHeaderView key="headerView" wantsLayer="YES" id="PKT-NF-xHB">
+                                    <rect key="frame" x="0.0" y="0.0" width="2611" height="23"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableHeaderView>
                             </scrollView>
@@ -811,7 +808,7 @@ DQ
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FBV-lJ-fAI">
-                                <rect key="frame" x="355" y="13" width="81" height="32"/>
+                                <rect key="frame" x="354" y="13" width="83" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="69" id="LJ8-MU-xu8"/>
                                     <constraint firstAttribute="width" constant="69" id="Vk5-xO-1fO"/>
@@ -853,7 +850,7 @@ Gw
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hCw-vZ-7Dv">
-                                <rect key="frame" x="62" y="404" width="370" height="17"/>
+                                <rect key="frame" x="62" y="405" width="370" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Present" id="U16-rC-PbY">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -861,7 +858,7 @@ Gw
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="r1u-vm-oul">
-                                <rect key="frame" x="62" y="360" width="370" height="18"/>
+                                <rect key="frame" x="62" y="362" width="368" height="16"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="14" id="mYV-nt-5VV"/>
                                 </constraints>
@@ -874,7 +871,7 @@ Gw
                                 </connections>
                             </button>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="t67-Cz-8Dn">
-                                <rect key="frame" x="20" y="351" width="410" height="5"/>
+                                <rect key="frame" x="20" y="352" width="410" height="5"/>
                             </box>
                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fZJ-iA-eBy">
                                 <rect key="frame" x="62" y="321" width="370" height="18"/>
@@ -885,7 +882,7 @@ Gw
                                 </buttonCell>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6dc-lf-7ip" userLabel="Checkbox Tickets Bought">
-                                <rect key="frame" x="62" y="380" width="370" height="18"/>
+                                <rect key="frame" x="62" y="382" width="368" height="16"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="2Mm-NH-fTQ"/>
                                     <constraint firstAttribute="height" constant="14" id="Mq9-c2-gEx"/>
@@ -900,7 +897,7 @@ Gw
                                 </connections>
                             </button>
                             <comboBox identifier="ratingCombo" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LTo-dB-IYk">
-                                <rect key="frame" x="20" y="319" width="38" height="22"/>
+                                <rect key="frame" x="20" y="320" width="38" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="35" id="2e4-eb-xdi"/>
                                     <constraint firstAttribute="height" constant="17" id="LCi-Ko-HxL"/>
@@ -998,19 +995,19 @@ Gw
         <scene sceneID="dwS-JR-0kj">
             <objects>
                 <viewController title="Film Ratings" id="gJ5-Ju-597" customClass="FilmRatingDialogController" sceneMemberID="viewController">
-                    <view key="view" id="elb-OS-w3T">
-                        <rect key="frame" x="0.0" y="0.0" width="922" height="729"/>
+                    <view key="view" misplaced="YES" id="elb-OS-w3T">
+                        <rect key="frame" x="0.0" y="0.0" width="917" height="705"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VCv-Jr-uiq">
-                                <rect key="frame" x="20" y="61" width="882" height="648"/>
+                                <rect key="frame" x="20" y="60" width="877" height="553"/>
                                 <clipView key="contentView" drawsBackground="NO" id="lfs-rW-7gy">
-                                    <rect key="frame" x="1" y="0.0" width="880" height="647"/>
+                                    <rect key="frame" x="1" y="1" width="875" height="551"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" columnSelection="YES" autosaveColumns="NO" rowSizeStyle="automatic" headerView="phV-Fb-8ew" viewBased="YES" id="yF0-fE-yMF">
-                                            <rect key="frame" x="0.0" y="0.0" width="880" height="624"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="875" height="528"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="2"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <tableViewGridLines key="gridStyleMask" vertical="YES"/>
@@ -1018,7 +1015,6 @@ Gw
                                             <tableColumns>
                                                 <tableColumn width="268" minWidth="40" maxWidth="1000" id="eJV-5g-p8v">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Film">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -1031,11 +1027,11 @@ Gw
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="mfG-jo-sdk">
-                                                            <rect key="frame" x="1" y="1" width="268" height="17"/>
+                                                            <rect key="frame" x="1" y="1" width="273" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="8cP-O0-MnO">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="272" height="17"/>
+                                                                    <rect key="frame" x="0.0" y="1" width="277" height="16"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="MVX-PR-TOF">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1056,7 +1052,6 @@ Gw
                                                 </tableColumn>
                                                 <tableColumn width="50" minWidth="10" maxWidth="3.4028234663852886e+38" id="4zx-VA-BOr">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Duration">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </tableHeaderCell>
@@ -1069,7 +1064,7 @@ Gw
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="eI1-bD-ViS">
-                                                            <rect key="frame" x="272" y="1" width="50" height="17"/>
+                                                            <rect key="frame" x="277" y="1" width="50" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6A6-gM-YDx">
@@ -1090,7 +1085,6 @@ Gw
                                                 </tableColumn>
                                                 <tableColumn width="60" minWidth="40" maxWidth="1000" id="9nw-pm-hYP">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Rating">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -1103,11 +1097,11 @@ Gw
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="un6-Fc-nqP">
-                                                            <rect key="frame" x="325" y="1" width="60" height="17"/>
+                                                            <rect key="frame" x="330" y="1" width="64" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="gM2-e9-wtb">
-                                                                    <rect key="frame" x="1" y="0.0" width="53" height="17"/>
+                                                                    <rect key="frame" x="1" y="1" width="53" height="16"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="49" id="DsQ-Ho-DaF"/>
                                                                     </constraints>
@@ -1133,21 +1127,21 @@ Gw
                                     </subviews>
                                     <nil key="backgroundColor"/>
                                 </clipView>
-                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="cJC-90-VbM">
+                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="cJC-90-VbM">
                                     <rect key="frame" x="1" y="631" width="466" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="mxQ-38-gJg">
+                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="mxQ-38-gJg">
                                     <rect key="frame" x="224" y="17" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <tableHeaderView key="headerView" id="phV-Fb-8ew">
-                                    <rect key="frame" x="0.0" y="0.0" width="880" height="23"/>
+                                <tableHeaderView key="headerView" wantsLayer="YES" id="phV-Fb-8ew">
+                                    <rect key="frame" x="0.0" y="0.0" width="875" height="23"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableHeaderView>
                             </scrollView>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gmW-ky-y0A">
-                                <rect key="frame" x="814" y="13" width="94" height="32"/>
+                                <rect key="frame" x="808" y="13" width="96" height="33"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="AVf-qz-DOg"/>
                                     <constraint firstAttribute="width" constant="82" id="Cc4-8b-n5R"/>
@@ -1164,14 +1158,14 @@ DQ
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0B2-hy-eMi">
-                                <rect key="frame" x="18" y="22" width="161" height="18"/>
+                                <rect key="frame" x="18" y="22" width="165" height="18"/>
                                 <buttonCell key="cell" type="check" title="Type-match entire title" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="p3r-Be-5p0">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Wfn-Xt-Gfg">
-                                <rect key="frame" x="704" y="13" width="110" height="32"/>
+                                <rect key="frame" x="698" y="13" width="112" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="98" id="JEH-kC-6JA"/>
                                     <constraint firstAttribute="width" constant="98" id="z9S-ay-bSg"/>
@@ -1182,7 +1176,7 @@ DQ
                                 </buttonCell>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Utj-eZ-Fhm">
-                                <rect key="frame" x="610" y="13" width="94" height="32"/>
+                                <rect key="frame" x="604" y="13" width="96" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="82" id="LeM-1a-lUT"/>
                                     <constraint firstAttribute="width" constant="82" id="gr0-Fb-3iX"/>
@@ -1196,7 +1190,7 @@ DQ
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HT7-GE-9go">
-                                <rect key="frame" x="567" y="13" width="43" height="32"/>
+                                <rect key="frame" x="561" y="13" width="45" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="31" id="eqI-ci-30M"/>
                                 </constraints>
@@ -1206,7 +1200,7 @@ DQ
                                 </buttonCell>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KcU-Ml-kPa">
-                                <rect key="frame" x="522" y="13" width="45" height="32"/>
+                                <rect key="frame" x="516" y="13" width="47" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="33" id="pk4-Na-i0V"/>
                                 </constraints>
@@ -1269,7 +1263,7 @@ DQ
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vQB-Q1-0Hr">
-                                <rect key="frame" x="18" y="212" width="448" height="17"/>
+                                <rect key="frame" x="18" y="213" width="448" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" title="Combine titles" id="egK-4k-I6e">
                                     <font key="font" metaFont="systemBold"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1277,7 +1271,7 @@ DQ
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FTn-ag-1L5">
-                                <rect key="frame" x="388" y="13" width="81" height="32"/>
+                                <rect key="frame" x="387" y="13" width="83" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="69" id="tVT-8k-dJn"/>
                                 </constraints>
@@ -1293,7 +1287,7 @@ DQ
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tS1-eg-574">
-                                <rect key="frame" x="307" y="13" width="82" height="32"/>
+                                <rect key="frame" x="306" y="13" width="84" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="70" id="r2P-ll-9Fo"/>
                                 </constraints>
@@ -1309,7 +1303,7 @@ Gw
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1Ul-mw-M44">
-                                <rect key="frame" x="18" y="187" width="446" height="17"/>
+                                <rect key="frame" x="18" y="189" width="446" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Pick the main title" id="Gfz-Uq-ihk">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1375,19 +1369,18 @@ Gw
                             <scrollView autohidesScrollers="YES" horizontalLineScroll="23" horizontalPageScroll="10" verticalLineScroll="23" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5mC-CG-pm4">
                                 <rect key="frame" x="0.0" y="0.0" width="1195" height="666"/>
                                 <clipView key="contentView" id="193-IC-dyH">
-                                    <rect key="frame" x="1" y="0.0" width="1193" height="665"/>
+                                    <rect key="frame" x="1" y="1" width="1193" height="664"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="21" rowSizeStyle="automatic" headerView="DSY-jX-vbt" viewBased="YES" indentationPerLevel="16" outlineTableColumn="0AG-oJ-qZC" id="4h4-IM-hVL">
-                                            <rect key="frame" x="0.0" y="0.0" width="3328" height="642"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="3337" height="641"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="2"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
                                                 <tableColumn width="237" minWidth="40" maxWidth="1000" id="0AG-oJ-qZC">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Not planned films">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -1399,11 +1392,11 @@ Gw
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="5Lr-x6-auc">
-                                                            <rect key="frame" x="1" y="1" width="237" height="21"/>
+                                                            <rect key="frame" x="11" y="1" width="242" height="21"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6Gi-s7-vza">
-                                                                    <rect key="frame" x="0.0" y="4" width="237" height="34"/>
+                                                                    <rect key="frame" x="0.0" y="4" width="242" height="34"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Film Title Cell" drawsBackground="YES" id="uFB-lZ-0sv">
                                                                         <font key="font" metaFont="system"/>
@@ -1420,7 +1413,6 @@ Gw
                                                 </tableColumn>
                                                 <tableColumn editable="NO" width="51" minWidth="40" maxWidth="1000" id="MbN-br-cxT">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="Rating">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -1432,7 +1424,7 @@ Gw
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="jey-5t-cfg">
-                                                            <rect key="frame" x="241" y="1" width="51" height="21"/>
+                                                            <rect key="frame" x="256" y="1" width="51" height="21"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dSK-9c-1j2">
@@ -1453,7 +1445,6 @@ Gw
                                                 </tableColumn>
                                                 <tableColumn width="28" minWidth="10" maxWidth="3.4028234663852886e+38" id="1cT-cs-Tmy">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Go">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </tableHeaderCell>
@@ -1465,7 +1456,7 @@ Gw
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="9SA-fs-5gB">
-                                                            <rect key="frame" x="295" y="1" width="28" height="17"/>
+                                                            <rect key="frame" x="310" y="1" width="28" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bOx-mk-MBB">
@@ -1486,7 +1477,6 @@ Gw
                                                 </tableColumn>
                                                 <tableColumn width="3000" minWidth="10" maxWidth="3.4028234663852886e+38" id="Go9-WO-KjZ">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Info">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </tableHeaderCell>
@@ -1498,11 +1488,11 @@ Gw
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="mIw-Ph-gMR">
-                                                            <rect key="frame" x="326" y="1" width="3000" height="17"/>
+                                                            <rect key="frame" x="341" y="1" width="3004" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5C7-ls-c4A">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="3000" height="17"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="3004" height="17"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Info Cell" id="3ma-d0-fXp">
                                                                         <font key="font" metaFont="system"/>
@@ -1521,16 +1511,16 @@ Gw
                                         </outlineView>
                                     </subviews>
                                 </clipView>
-                                <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="dxt-iz-zQJ">
+                                <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="dxt-iz-zQJ">
                                     <rect key="frame" x="1" y="649" width="1193" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="thK-pP-gKv">
+                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="thK-pP-gKv">
                                     <rect key="frame" x="224" y="17" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <tableHeaderView key="headerView" id="DSY-jX-vbt">
-                                    <rect key="frame" x="0.0" y="0.0" width="3328" height="23"/>
+                                <tableHeaderView key="headerView" wantsLayer="YES" id="DSY-jX-vbt">
+                                    <rect key="frame" x="0.0" y="0.0" width="3337" height="23"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableHeaderView>
                             </scrollView>
@@ -1554,15 +1544,15 @@ Gw
             <point key="canvasLocation" x="1704" y="643"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="GdS-O0-lhM"/>
+        <segue reference="aIf-jF-vlz"/>
+    </inferredMetricsTieBreakers>
     <resources>
-        <image name="NSActionTemplate" width="14" height="14"/>
+        <image name="NSActionTemplate" width="15" height="15"/>
         <image name="NSFolderSmart" width="32" height="32"/>
         <image name="NSInfo" width="32" height="32"/>
         <image name="NSNetwork" width="32" height="32"/>
         <sound name="Glass"/>
     </resources>
-    <inferredMetricsTieBreakers>
-        <segue reference="Aco-xL-TKu"/>
-        <segue reference="MQZ-rL-cxz"/>
-    </inferredMetricsTieBreakers>
 </document>

--- a/PresentScreenings/Utilities/ControlsFactory.cs
+++ b/PresentScreenings/Utilities/ControlsFactory.cs
@@ -84,12 +84,15 @@ namespace PresentScreenings.TableView
             return comboBox;
         }
 
-        public static NSScrollView NewStandardScrollView(CGRect frame, NSView documentView, bool debug = false)
+        public static NSScrollView NewStandardScrollView(CGRect frame, NSView documentView, bool useWindowsBackgroundCoplor = false, bool debug = false)
         {
             var scrollView = new NSScrollView(frame);
-            scrollView.BackgroundColor = NSColor.WindowBackground;
             scrollView.BorderType = NSBorderType.BezelBorder;
             scrollView.DocumentView = documentView;
+            if (useWindowsBackgroundCoplor)
+            {
+                scrollView.BackgroundColor = NSColor.WindowBackground;
+            }
             if (frame.Width > documentView.Frame.Width)
             {
                 documentView.SetFrameSize(new CGSize(frame.Width, documentView.Frame.Height));


### PR DESCRIPTION
PresentScreenings/Utilities/ControlsFactory.cs, PresentScreenings/Controllers/ViewController.cs, PresentScreenings/Controllers/ScreeningDialogController.cs, PresentScreenings/Controllers/AvailabilityDialogControler.cs, PresentScreenings/Controllers/UncombineTitlesSheetController.cs:
Big Sur make-over.

PresentScreenings/Controllers/FilmRatingDialogController.cs:
Use separate Original Film ID and Film ID To Be Changed When Combining Titles for screenings.

PresentScreenings/Entities/Screening.cs, PresentScreenings/Entities/ScreeningInfo.cs:
Use separate film ID's for original title and combined titles.

PresentScreenings/Main.storyboard:
Big Sur make-over?