### PR TITLE
Support IFFR 2022

### DIFF
--- a/FilmFestivalLoader/IFFR/parse_iffr_html.py
+++ b/FilmFestivalLoader/IFFR/parse_iffr_html.py
@@ -16,7 +16,6 @@ import web_tools
 festival = 'IFFR'
 year = 2022
 city = 'Rotterdam'
-june_edition_start_date = datetime.date(year, 6, 1)
 
 # Directories.
 documents_dir = os.path.expanduser("~/Documents/Film/{0}/{0}{1}".format(festival, year))
@@ -41,9 +40,9 @@ def main():
     Globals.debug_recorder = app_tools.DebugRecorder(debug_file)
 
     # Initialize a festival data object.
-    iffr_data = IffrData(plandata_dir)
+    iffr_data: IffrData = IffrData(plandata_dir)
 
-    # Try parsing the web sites.
+    # Try parsing the websites.
     write_film_list = False
     write_other_lists = True
     try:
@@ -160,7 +159,6 @@ class AzPageParser(HtmlPageParser):
         self.init_film_data()
 
     def parse_props(self, data):
-        # for g in [m.groupdict() for m in self.props_re.finditer(data)]:
         i = self.props_re.finditer(data)
         matches = [match for match in i]
         groups = [m.groupdict() for m in matches]
@@ -189,7 +187,7 @@ class AzPageParser(HtmlPageParser):
         if self.film is None:
             Globals.error_collector.add(f'Could\'t create film from {self.title}', self.url)
         else:
-            self.film.medium_category = self.url.split('/')[5]
+            self.film.medium_category = self.url.split('/')[6]
             self.film.duration = self.duration
             self.film.sortstring = self.sorted_title
             print(f'Adding FILM: {self.title} ({self.film.duration_str()}) {self.film.medium_category}')
@@ -557,9 +555,8 @@ class IffrData(planner.FestivalData):
     def _filmkey(self, film, url):
         return url
 
-    def screening_can_go_to_planner(self, screening):
-        in_june_edition = screening.start_datetime.date() >= june_edition_start_date
-        return in_june_edition and planner.FestivalData.screening_can_go_to_planner(self, screening)
+    def film_can_go_to_planner(self, filmid):
+        return True
 
 
 if __name__ == "__main__":

--- a/FilmFestivalLoader/Imagine/parse_imagine_html.py
+++ b/FilmFestivalLoader/Imagine/parse_imagine_html.py
@@ -153,10 +153,10 @@ class AzPageParser(HtmlPageParser):
         self.init_film_data()
 
     def init_catagories(self):
-        planner.Film.filmcategory_by_string['feature'] = planner.Film.category_films
-        planner.Film.filmcategory_by_string['special'] = planner.Film.category_events
-        planner.Film.filmcategory_by_string['talk'] = planner.Film.category_events
-        planner.Film.filmcategory_by_string['workshop'] = planner.Film.category_events
+        planner.Film.category_by_string['feature'] = planner.Film.category_films
+        planner.Film.category_by_string['special'] = planner.Film.category_events
+        planner.Film.category_by_string['talk'] = planner.Film.category_events
+        planner.Film.category_by_string['workshop'] = planner.Film.category_events
 
     def init_film_data(self):
         self.film = None

--- a/FilmFestivalLoader/Shared/planner_interface.py
+++ b/FilmFestivalLoader/Shared/planner_interface.py
@@ -49,10 +49,7 @@ class Film:
     category_films = "Films"
     category_combinations = "CombinedProgrammes"
     category_events = "Events"
-    filmcategory_by_string = {}
-    filmcategory_by_string["films"] = category_films
-    filmcategory_by_string["verzamelprogrammas"] = category_combinations
-    filmcategory_by_string["events"] = category_events
+    category_by_string = dict(films=category_films, verzamelprogrammas=category_combinations, events=category_events)
     mapper = UnicodeMapper()
     articles_by_language = {}
     language_by_title = {}
@@ -66,7 +63,7 @@ class Film:
         self.title_language = self.language()
         self.section = ""
         self.duration = None
-        self.medium_category = url.split("/")[5]
+        self.medium_category = url.split("/")[6]
         self.sortstring = self.lower(self.strip_article())
 
     def __str__(self):
@@ -98,7 +95,7 @@ class Film:
             self.title_language,
             self.section,
             self.duration_str(),
-            self.filmcategory_by_string[self.medium_category],
+            self.category_by_string[self.medium_category],
             self.url
         ])
         return "{}\n".format(text)

--- a/PresentScreenings/AppDelegate.cs
+++ b/PresentScreenings/AppDelegate.cs
@@ -44,10 +44,10 @@ namespace PresentScreenings.TableView
             // Preferences.
             Festival = "IFFR";
             FestivalYear = "2021";
-            VisitPhysical = false;
+            VisitPhysical = true;
             PauseBetweenOnDemandScreenings = new TimeSpan(0, 30, 0);
             Screening.TravelTime = new TimeSpan(0, 30, 0);
-            FilmRatingDialogController.OnlyFilmsWithScreenings = true;
+            FilmRatingDialogController.OnlyFilmsWithScreenings = false;
             FilmRatingDialogController.MinimalDuration = new TimeSpan(0, 35, 0);
             ScreeningControl.UseCoreGraphics = false;
 

--- a/PresentScreenings/Entities/Screen.cs
+++ b/PresentScreenings/Entities/Screen.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace PresentScreenings.TableView
@@ -9,6 +10,16 @@ namespace PresentScreenings.TableView
 
     public class Screen : ListStreamer, IComparable
     {
+        #region Private Members
+        private enum ScreenTypeSortCode
+        {
+            OnLine,
+            OnDemand,
+            Location
+        }
+        private static Dictionary<ScreenType, ScreenTypeSortCode> sortCodeByType;
+        #endregion
+
         #region Public Members
         public enum ScreenType
         {
@@ -28,6 +39,15 @@ namespace PresentScreenings.TableView
         #endregion
 
         #region Constructors
+        // Static constructor.
+        static Screen()
+        {
+            sortCodeByType = new Dictionary<ScreenType, ScreenTypeSortCode> { };
+            sortCodeByType.Add(ScreenType.OnLine, ScreenTypeSortCode.OnLine);
+            sortCodeByType.Add(ScreenType.OnDemand, ScreenTypeSortCode.OnDemand);
+            sortCodeByType.Add(ScreenType.Location, ScreenTypeSortCode.Location);
+        }
+
         // Empty constructor to facilitate ListStreamer method calls.
         public Screen() { }
 
@@ -80,27 +100,15 @@ namespace PresentScreenings.TableView
         #region Private Methods
         private string ToCompareString()
         {
-            string typeString = "9";
-            switch (Type)
-            {
-                case ScreenType.Location:
-                    typeString = "3";
-                    break;
-                case ScreenType.OnDemand:
-                    typeString = "2";
-                    break;
-                case ScreenType.OnLine:
-                    typeString = "1";
-                    break;
-            }
-            string compareString = $"{typeString}.{Abbreviation}";
+            int typeCode = (int)sortCodeByType[Type];
+            string compareString = $"{typeCode}.{Abbreviation}";
             Match match = ScreenRegex.Match(Abbreviation);
             if (match != null)
             {
                 string root = match.Groups[1].Value;
                 string postfix = match.Groups[2].Value;
                 int number = postfix.Length == 0 ? 0 : int.Parse(postfix);
-                compareString = $"{typeString}.{root}.{number:d3}";
+                compareString = $"{typeCode}.{root}.{number:d3}";
             }
             return compareString;
         }


### PR DESCRIPTION
Support IFFR 2022

* parse_iffr_html.py:
  Changes to fit the IFFR 2022 edition.

* parse_imagine_html.py:
  Dictionary name shortened.

* planner_interface.py:
  Shorten dictionary name.
Actualize place of medium categpry n URL.

* AppDelegate.cs:
  Change Preference Variables as to fit the IFFR 2022 edition.

* Screen.cs:
  Replace magic numbers by an enumeration.