### PR TITLE
Use screened film types to improve descriptions

### DIFF
--- a/FilmFestivalLoader/IFFR/run_iffr_unit_tests.py
+++ b/FilmFestivalLoader/IFFR/run_iffr_unit_tests.py
@@ -27,7 +27,9 @@ def main():
              repair_url_works,
              repair_url_pass,
              append_combination_0,
-             append_combination_1]
+             append_combination_1,
+             new_screened_film_0,
+             new_screened_film_1]
     test_tools.execute_tests(tests)
 
 
@@ -87,14 +89,14 @@ def test_new_name_first():
 
     # Arrange.
     screen_splitter = iffr.ScreenSplitter(iffr.plandata_dir)
-    testname = 'offline'
+    test_name = 'offline'
     names = ['offline']
 
     # Act.
-    newname = screen_splitter.new_name(testname, names)
+    new_name = screen_splitter.new_name(test_name, names)
 
     # Assert.
-    return newname, 'offline2'
+    return new_name, 'offline2'
 
 
 @test_tools.equity_decorator
@@ -102,14 +104,14 @@ def test_new_name_not():
 
     # Arrange.
     screen_splitter = iffr.ScreenSplitter(iffr.plandata_dir)
-    testname = 'offline'
+    test_name = 'offline'
     names = []
 
     # Act.
-    newname = screen_splitter.new_name(testname, names)
+    new_name = screen_splitter.new_name(test_name, names)
 
     # Assert.
-    return newname, 'offline'
+    return new_name, 'offline'
 
 
 @test_tools.equity_decorator
@@ -117,14 +119,14 @@ def test_new_name_gap():
 
     # Arrange.
     screen_splitter = iffr.ScreenSplitter(iffr.plandata_dir)
-    testname = 'offline'
+    test_name = 'offline'
     names = ['offline', 'offline3']
 
     # Act.
-    newname = screen_splitter.new_name(testname, names)
+    new_name = screen_splitter.new_name(test_name, names)
 
     # Assert.
-    return newname, 'offline2'
+    return new_name, 'offline2'
 
 
 @test_tools.equity_decorator
@@ -132,14 +134,14 @@ def test_new_name_next():
 
     # Arrange.
     screen_splitter = iffr.ScreenSplitter(iffr.plandata_dir)
-    testname = 'offline199'
+    test_name = 'offline199'
     names = ['offline199', 'offline200']
 
     # Act.
-    newname = screen_splitter.new_name(testname, names)
+    new_name = screen_splitter.new_name(test_name, names)
 
     # Assert.
-    return newname, 'offline201'
+    return new_name, 'offline201'
 
 
 @test_tools.equity_decorator
@@ -245,6 +247,38 @@ def append_combination_1():
 
     # Assert.
     return film_infos[1].combination_films[0], first_film
+
+
+@test_tools.equity_decorator
+def new_screened_film_0():
+    # Arrange.
+    film = TestList.festival_data.films[0]
+    film_id = film.filmid
+    title = film.title
+    description = TestList.test_films[0].description
+    sf_type = planner_interface.ScreenedFilmType.SCREENED_BEFORE
+
+    # Act.
+    screened_film = planner_interface.ScreenedFilm(film_id, title, description, sf_type)
+
+    # Assert.
+    return screened_film.screened_film_type, planner_interface.ScreenedFilmType.SCREENED_BEFORE
+
+
+@test_tools.equity_decorator
+def new_screened_film_1():
+    # Arrange.
+    film = TestList.festival_data.films[0]
+    film_id = film.filmid
+    title = film.title
+    description = TestList.test_films[0].description
+    sf_type = planner_interface.ScreenedFilmType.SCREENED_AFTER
+
+    # Act.
+    screened_film = planner_interface.ScreenedFilm(film_id, title, description, sf_type)
+
+    # Assert.
+    return screened_film.screened_film_type.name, 'SCREENED_AFTER'
 
 
 if __name__ == '__main__':

--- a/FilmFestivalLoader/Shared/planner_interface.py
+++ b/FilmFestivalLoader/Shared/planner_interface.py
@@ -11,6 +11,7 @@ Created on Sat Oct 10 18:13:42 2020
 import os
 import re
 import xml.etree.ElementTree as ET
+from enum import Enum, auto
 
 interface_dir = os.path.expanduser("~/Projects/FilmFestivalPlanner/FilmFestivalLoader/Shared")
 articles_file = os.path.join(interface_dir, "articles.txt")
@@ -154,18 +155,33 @@ class Film:
         return "{}, {}".format(rest, first)
 
 
+class ScreenedFilmType(Enum):
+    PART_OF_COMBINATION_PROGRAM = auto()
+    SCREENED_BEFORE = auto()
+    SCREENED_AFTER = auto()
+    DIRECTLY_COMBINED = auto()
+
+
 class ScreenedFilm:
 
-    def __init__(self, filmid, title, description):
-        self.filmid = filmid
+    def __init__(self, film_id, title, description, sf_type: ScreenedFilmType = ScreenedFilmType.PART_OF_COMBINATION_PROGRAM):
+        """
+        Screened Film: representation of a film that
+        is displayed as part of combination program.
+
+        @type film_id: int
+        @type title: str
+        @type description: str
+        """
+        self.filmid = film_id
         if title is None or len(title) == 0:
             raise FilmTitleError(description)
         self.title = title
         self.description = description if description is not None else ''
+        self.screened_film_type = sf_type
 
     def __str__(self):
         return ' - '.join([str(self.filmid), self.title])
-
 
 class FilmInfo:
 
@@ -418,7 +434,8 @@ class FestivalData:
                 _ = ET.SubElement(screened_films, 'ScreenedFilm',
                                   ScreenedFilmId=str(screened_film.filmid),
                                   Title=screened_film.title,
-                                  Description=screened_film.description)
+                                  Description=screened_film.description,
+                                  ScreenedFilmType=screened_film.screened_film_type.name)
         tree = ET.ElementTree(filminfos)
         tree.write(self.filminfo_file, encoding='utf-8', xml_declaration=True)
         print(f"Done writing {info_count} records to {self.filminfo_file}.")

--- a/PresentScreenings/Entities/FilmInfo.cs
+++ b/PresentScreenings/Entities/FilmInfo.cs
@@ -10,18 +10,31 @@ namespace PresentScreenings.TableView
 {
     public class FilmInfo
     {
+        #region Public Enumerations.
+        public enum ScreenedFilmType
+        {
+            PartOfCombinationProgram,
+            ScreenedBefore,
+            ScreenedAfter,
+            DirectlyCombined
+
+        }
+        #endregion
+
         #region Public Sub-classes.
         public class ScreenedFilm
         {
             public int ScreenedFilmId { get; }
             public string Title { get; }
             public string Description { get; }
+            public ScreenedFilmType ScreenedFilmType { get; }
 
-            public ScreenedFilm(int screenedFilmId, string title, string description)
+            public ScreenedFilm(int screenedFilmId, string title, string description, ScreenedFilmType screenedFilmType)
             {
                 ScreenedFilmId = screenedFilmId;
                 Title = title;
                 Description = description;
+                ScreenedFilmType = screenedFilmType;
             }
 
             public override string ToString()
@@ -31,6 +44,12 @@ namespace PresentScreenings.TableView
                 return titleText + Environment.NewLine + Description;
             }
         }
+        #endregion
+
+        #region Static Private Members
+        private static readonly Dictionary<string, ScreenedFilmType> _screenedFilmTypeByString;
+        private static readonly Dictionary<ScreenedFilmType, string> _partByScreenedFilmType;
+        private static readonly Dictionary<ScreenedFilmType, string> _headerByScreenedFilmType;
         #endregion
 
         #region Properties
@@ -45,6 +64,25 @@ namespace PresentScreenings.TableView
         #endregion
 
         #region Constructors
+        static FilmInfo()
+        {
+            _screenedFilmTypeByString = new Dictionary<string, ScreenedFilmType> { };
+            _screenedFilmTypeByString.Add("DIRECTLY_COMBINED", ScreenedFilmType.DirectlyCombined);
+            _screenedFilmTypeByString.Add("PART_OF_COMBINATION_PROGRAM", ScreenedFilmType.PartOfCombinationProgram);
+            _screenedFilmTypeByString.Add("SCREENED_AFTER", ScreenedFilmType.ScreenedAfter);
+            _screenedFilmTypeByString.Add("SCREENED_BEFORE", ScreenedFilmType.ScreenedBefore);
+            _partByScreenedFilmType = new Dictionary<ScreenedFilmType, string> { };
+            _partByScreenedFilmType.Add(ScreenedFilmType.PartOfCombinationProgram, "Screened as part of");
+            _partByScreenedFilmType.Add(ScreenedFilmType.ScreenedBefore, "Screened before");
+            _partByScreenedFilmType.Add(ScreenedFilmType.ScreenedAfter, "Screened after");
+            _partByScreenedFilmType.Add(ScreenedFilmType.DirectlyCombined, "Screened in combination with");
+            _headerByScreenedFilmType = new Dictionary<ScreenedFilmType, string> { };
+            _headerByScreenedFilmType.Add(ScreenedFilmType.PartOfCombinationProgram, "Screened films");
+            _headerByScreenedFilmType.Add(ScreenedFilmType.ScreenedBefore, "Screened before the main feature");
+            _headerByScreenedFilmType.Add(ScreenedFilmType.ScreenedAfter, "Screened after the main feature");
+            _headerByScreenedFilmType.Add(ScreenedFilmType.DirectlyCombined, "Screened in combination with");
+        }
+
         public FilmInfo(int filmId, Film.FilmInfoStatus infoStatus, string description, string article)
         {
             FilmId = filmId;
@@ -59,39 +97,85 @@ namespace PresentScreenings.TableView
         #region Override Methods
         public override string ToString()
         {
-            var builder = new StringBuilder(Url + Environment.NewLine);
+            var newLine = Environment.NewLine;
+            var twoLines = newLine + newLine;
+            var builder = new StringBuilder(Url + newLine);
             if (FilmDescription != string.Empty)
             {
-                builder.AppendLine(Environment.NewLine + "Description");
+                builder.AppendLine(newLine + "Description");
                 builder.AppendLine(FilmDescription);
             }
             if (FilmArticle != string.Empty)
             {
-                builder.AppendLine(Environment.NewLine + "Article");
+                builder.AppendLine(newLine + "Article");
                 builder.AppendLine(FilmArticle);
             }
             if (CombinationProgramIds.Count > 0)
             {
-                builder.AppendLine(Environment.NewLine + "Screened as part of:");
-                builder.AppendJoin(Environment.NewLine, (
-                    from int filmId in CombinationProgramIds
-                    select ViewController.GetFilmById(filmId)
-                ));
+                // Per combination program, find its screened film that matches
+                // the current film and create a list of combination program -
+                // screened film pairs.
+                var combinationScreenedPairs = CombinationProgramIds
+                    .Select(i => ViewController.GetFilmById(i))
+                    .SelectMany(cf => cf.FilmInfo.ScreenedFilms
+                        .Select(sf => new { cf, sf })
+                        .Where(pair => pair.sf.ScreenedFilmId == FilmId));
+
+                // Store each screened film type together with the combination
+                // programs it is paired with.
+                var combinationsByType = new Dictionary<ScreenedFilmType, List<Film>> { };
+                foreach (var pair in combinationScreenedPairs)
+                {
+                    if (!combinationsByType.Keys.Contains(pair.sf.ScreenedFilmType))
+                    {
+                        combinationsByType.Add(pair.sf.ScreenedFilmType, new List<Film> { });
+                    }
+                    combinationsByType[pair.sf.ScreenedFilmType].Add(pair.cf);
+                }
+
+                // Per type, add the applicable header and the combination
+                // programs in which this film has that type to the string
+                // builder.
+                var space = newLine;
+                foreach (var screenedFilmType in combinationsByType.Keys)
+                {
+                    builder.AppendLine($"{space}{_partByScreenedFilmType[screenedFilmType]}:");
+                    builder.AppendJoin(
+                        newLine,
+                        combinationsByType[screenedFilmType]);
+                    space = twoLines;
+                }
             }
             if (ScreenedFilms.Count > 0)
             {
-                builder.AppendLine(Environment.NewLine + "Screened films");
-                var space = Environment.NewLine + Environment.NewLine;
-                builder.AppendLine(string.Join(space, ScreenedFilms.Select(f => f.ToString())));
+                // Create a list of the distinct screened film types in the
+                // screened films.
+                var screenedFilmTypes = ScreenedFilms
+                    .Select(sf => sf.ScreenedFilmType)
+                    .Distinct();
+                var space = newLine;
+
+                // Per type, add the applicible header and the screened films
+                // with that type to the string builder.
+                foreach (var screenedFilmType in screenedFilmTypes)
+                {
+                    builder.AppendLine($"{space}{_headerByScreenedFilmType[screenedFilmType]}:");
+                    var screenedFilmsOfType = ScreenedFilms
+                        .Where(sf => sf.ScreenedFilmType == screenedFilmType);
+                    builder.AppendJoin(
+                        twoLines,
+                        screenedFilmsOfType.Select(f => f.ToString()));
+                    space = twoLines;
+                }
             }
             return builder.ToString();
         }
         #endregion
 
         #region Public Methods
-        public void AddScreenedFilm(int filmid, string title, string description)
+        public void AddScreenedFilm(int filmid, string title, string description, ScreenedFilmType screenedFilmType)
         {
-            var screenedFilm = new ScreenedFilm(filmid, title, description);
+            var screenedFilm = new ScreenedFilm(filmid, title, description, screenedFilmType);
             ScreenedFilms.Add(screenedFilm);
         }
 
@@ -129,7 +213,8 @@ namespace PresentScreenings.TableView
                     (
                         (string)s.Attribute("ScreenedFilmId"),
                         (string)s.Attribute("Title"),
-                        (string)s.Attribute("Description")
+                        (string)s.Attribute("Description"),
+                        (string)s.Attribute("ScreenedFilmType")
                     )
                 );
             foreach (var filmInfoElement in filmInfoElements)
@@ -150,7 +235,9 @@ namespace PresentScreenings.TableView
                     int filmid = int.Parse(screenedFilmAttribute.Item1);
                     var title = screenedFilmAttribute.Item2;
                     var description = screenedFilmAttribute.Item3;
-                    filmInfo.AddScreenedFilm(filmid, title, description);
+                    var type = screenedFilmAttribute.Item4;
+                    var screenedFilmType = _screenedFilmTypeByString[type];
+                    filmInfo.AddScreenedFilm(filmid, title, description, screenedFilmType);
                 }
                 filmInfos.Add(filmInfo);
             }

--- a/PresentScreenings/Entities/FilmInfo.cs
+++ b/PresentScreenings/Entities/FilmInfo.cs
@@ -17,7 +17,6 @@ namespace PresentScreenings.TableView
             ScreenedBefore,
             ScreenedAfter,
             DirectlyCombined
-
         }
         #endregion
 


### PR DESCRIPTION
* parse_iffr_html.py:
  Support new Screened Film field Screned Film Type.

* run_iffr_unit_tests.py:
  Add two unit tests for the introduction of the Screened Film Type
field.
Some renaming to fight 'typo' warnings.

* planner_interface.py:
  Introduce new Screened Film field Screned Film Type.

* FilmInfo.cs:
  Apply new Screened Film field Screned Film Type.