### PR TITLE
Close FilmInfo Dialog when switching screening

### DIFF
--- a/FilmFestivalLoader/IFFR/parse_iffr_html.py
+++ b/FilmFestivalLoader/IFFR/parse_iffr_html.py
@@ -15,7 +15,7 @@ import web_tools
 
 # Parameters.
 festival = 'IFFR'
-festival_year = 2022
+festival_year = 2021
 city = 'Rotterdam'
 
 # Directories.

--- a/PresentScreenings/AppDelegate.cs
+++ b/PresentScreenings/AppDelegate.cs
@@ -52,7 +52,7 @@ namespace PresentScreenings.TableView
 		{
             // Preferences.
             Festival = "IFFR";
-            FestivalYear = "2022";
+            FestivalYear = "2021";
             VisitPhysical = true;
             PauseBetweenOnDemandScreenings = new TimeSpan(0, 30, 0);
             Screening.TravelTime = new TimeSpan(0, 30, 0);
@@ -248,6 +248,10 @@ namespace PresentScreenings.TableView
             if (FilmsDialogController != null)
             {
                 FilmsDialogController.CloseDialog();
+            }
+            if (FilmInfoController != null)
+            {
+                FilmInfoController.CloseDialog();
             }
             if (AnalyserDialogController != null)
             {

--- a/PresentScreenings/Controllers/FilmInfoDialogController.cs
+++ b/PresentScreenings/Controllers/FilmInfoDialogController.cs
@@ -104,6 +104,13 @@ namespace PresentScreenings.TableView
         }
         #endregion
 
+        #region Public Methods
+        public void CloseDialog()
+        {
+            Presentor.DismissViewController(this);
+        }
+        #endregion
+
         #region Private Methods
         private void PopulatieDialogView()
         {
@@ -275,11 +282,6 @@ namespace PresentScreenings.TableView
         {
             Presentor.GoToScreening(screening);
             CloseDialog();
-        }
-
-        private void CloseDialog()
-        {
-            Presentor.DismissViewController(this);
         }
         #endregion
 

--- a/PresentScreenings/Menu Delegates/ScreeningMenuDelegate.cs
+++ b/PresentScreenings/Menu Delegates/ScreeningMenuDelegate.cs
@@ -264,9 +264,9 @@ namespace PresentScreenings.TableView
         private void PopulateFilmScreeningsMenuItems(NSMenu menu)
         {
             // Remove the existing screening items from the menu.
-            foreach (var item in _filmScreeningByMenuItemTitle.Keys)
+            foreach (string title in _filmScreeningByMenuItemTitle.Keys)
             {
-                menu.RemoveItem(menu.ItemWithTitle(item));
+                menu.RemoveItem(menu.ItemWithTitle(title));
             }
 
             // Add the screenings with same film to the Screening menu.

--- a/Tools/diff_films.sh
+++ b/Tools/diff_films.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+declare -r old_dir=${1:-FestivalPlan}
+declare -r new_dir=${2:-_planner_data}
+declare -r festival_year=$(basename $(dirname $(pwd)))
+declare -r festival=${festival_year:0:4}
+declare -r year=${festival_year:4:4}
+declare -r documents_dir=~/Documents/Film/${festival}/${festival_year}
+declare -r csv_file=films.csv
+
+cd $documents_dir
+echo "$old_dir <> $new_dir"
+diff <(cut -d";" -f2- $old_dir/$csv_file | sort -k1n) <(cut -d";" -f2- $new_dir/$csv_file | sort -k1n)


### PR DESCRIPTION
* diff_films.sh:
  Centralized an existing, useful tool.

* parse_iffr_html.py:
  Change year to 2021 for reprocing and testing.

* AppDelegate.cs:
  Change year to 2021 for reprocing and testing.
Close Film Info Dialog when navigating to a new screening.

* FilmInfoDialogController.cs:
  Make the CloseDialog method of the Film Info Dialog public.

* ScreeningMenuDelegate.cs:
  Rename loop variable as boy scout action.