### PR TITLE
Alert for coinciding screenings

### DIFF
--- a/PresentScreenings/AppDelegate.cs
+++ b/PresentScreenings/AppDelegate.cs
@@ -93,8 +93,12 @@ namespace PresentScreenings.TableView
             _combineTitlesMenuItem.Action = new Selector("SelectTitlesToCombine:");
             _uncombineTitleMenuItem.Action = new Selector("ShowTitlesToUncombine:");
             Controller.ClickableLabelsMenuItem = _clickableLabelsMenuItem;
-		}
-        
+
+            // Report coinciding screenings.
+            ViewController.ReportDuplicateScreenings();
+            ViewController.ReportCoincidingScreeninings();
+        }
+
         public override void WillTerminate(NSNotification notification)
 		{
 			// Insert code here to tear down your application

--- a/PresentScreenings/Entities/FilmInfo.cs
+++ b/PresentScreenings/Entities/FilmInfo.cs
@@ -20,7 +20,7 @@ namespace PresentScreenings.TableView
         }
         #endregion
 
-        #region Public Sub-classes.
+        #region Public Nested Classes.
         public class ScreenedFilm
         {
             public int ScreenedFilmId { get; }

--- a/PresentScreenings/Entities/Screening.cs
+++ b/PresentScreenings/Entities/Screening.cs
@@ -41,6 +41,7 @@ namespace PresentScreenings.TableView
         public Film Film { get => ViewController.GetFilmById(FilmId); set => FilmId = value.FilmId; }
         public string FilmTitle => Film.Title;
         public string ScreeningTitle => ViewController.GetFilmById(OriginalFilmId).Title;
+        public string CoincideKey => GetCoincideKey();
         public Screen DisplayScreen { get => GetDisplayScreen(); set => SetDisplayScreen(value); }
         public DateTime StartTime { get => _screeningInfo.MovableStartTime; protected set => _screeningInfo.MovableStartTime = value; }
         public DateTime EndTime { get => _screeningInfo.MovableEndTime; protected set => _screeningInfo.MovableEndTime = value; }
@@ -426,6 +427,31 @@ namespace PresentScreenings.TableView
         {
             return string.Format("{0}-{1}", StartTime.ToString(_timeFormat), EndTime.ToString(_timeFormat));
         }
-                    #endregion
+
+        private string GetCoincideKey()
+        {
+            string weekDay = $"{StartTime.DayOfWeek.ToString().Remove(3)}";
+            string dateTime = $"{StartTime:yyyy-MM-dd HH:mm}";
+            TimeSpan duration = EndTime - StartTime;
+            return $"{Screen}, {weekDay} {dateTime} ({duration:hh\\:mm})";
+        }
+        #endregion
+    }
+
+    internal class ScreeningEqualityComparer : IEqualityComparer<Screening>
+    {
+        bool IEqualityComparer<Screening>.Equals(Screening screening, Screening otherScreening)
+        {
+            return screening.OriginalFilmId == otherScreening.OriginalFilmId
+                && screening.Screen.ToString() == otherScreening.Screen.ToString()
+                && screening.StartTime == otherScreening.StartTime
+                && screening.EndTime == otherScreening.EndTime;
+        }
+
+        int IEqualityComparer<Screening>.GetHashCode(Screening screening)
+        {
+            string key = $"{screening.Screen}.{screening.StartTime}.{screening.EndTime}.{screening.OriginalFilmId}";
+            return key.GetHashCode();
+        }
     }
 }

--- a/PresentScreenings/Entities/ScreeningsPlan.cs
+++ b/PresentScreenings/Entities/ScreeningsPlan.cs
@@ -67,10 +67,9 @@ namespace PresentScreenings.TableView
             ScreeningInfos = new ScreeningInfo()
                 .ReadListFromFile(AppDelegate.ScreeningInfoFile, line => new ScreeningInfo(line));
 
-            // Read unique screenings.
+            // Read screenings.
             Screenings = new Screening()
                 .ReadListFromFile(AppDelegate.ScreeningsFile, line => PickScreening(line));
-            ViewController.RemoveDuplicateScreenings();
 
             // Filter out screenings that are screened in a combination program.
             SetDisplayedScreenings();

--- a/PresentScreenings/Menu Delegates/ScreeningMenuDelegate.cs
+++ b/PresentScreenings/Menu Delegates/ScreeningMenuDelegate.cs
@@ -293,10 +293,7 @@ namespace PresentScreenings.TableView
                 menu.AddItem(item);
                 bool enabled = AnalyserViewRunning() || screening != Screening;
                 _FilmScreeningEnabledByTag.Add(item.Tag, enabled);
-                if (!_filmScreeningByMenuItemTitle.ContainsKey(itemTitle))
-                {
-                    _filmScreeningByMenuItemTitle.Add(itemTitle, screening);
-                }
+                _filmScreeningByMenuItemTitle.Add(itemTitle, screening);
             }
         }
 

--- a/PresentScreenings/Utilities/AlertRaiser.cs
+++ b/PresentScreenings/Utilities/AlertRaiser.cs
@@ -9,7 +9,7 @@ namespace PresentScreenings.TableView
     /// <summary>
     /// Alert Raiser, stops the application after writing a stack dump on file
     /// and displaying an alert.
-    /// If no alert can be displayed, a usrr notification is raised.
+    /// If no alert can be displayed, a user notification is raised.
     /// </summary>
     public static class AlertRaiser
     {
@@ -65,20 +65,37 @@ namespace PresentScreenings.TableView
             }
         }
 
-        public static void RunInformationalAlert(string messageText, string informativeText)
+        public static void RunInformationalAlert(string messageText, string informativeText, bool saveText=false)
         {
             var alert = new NSAlert()
             {
                 AlertStyle = NSAlertStyle.Informational,
                 MessageText = messageText,
-                InformativeText = informativeText
+                InformativeText = informativeText,
             };
-            alert.RunModal();
+            if (saveText)
+            {
+                alert.AddButton("OK");
+                alert.AddButton("Save");
+            }
+            var result = alert.RunModal();
+
+            // Save the text in the errorfile when the Save button is hit.
+            if (result == 1001)
+            {
+                WriteToErrorlog(informativeText);
+                RaiseNotification("Alert text is saved", $"Text saved to {ErrorFile}");
+            }
         }
 
         public static void WriteToErrorlog(Exception ex, Exception ex2 = null)
         {
-            System.IO.File.WriteAllText(ErrorFile, ErrorString(ex, ex2));
+            WriteToErrorlog(ErrorString(ex, ex2));
+        }
+
+        public static void WriteToErrorlog(string text)
+        {
+            System.IO.File.WriteAllText(ErrorFile, text);
         }
 
         public static void RaiseNotification(string title, string text)


### PR DESCRIPTION
* AppDelegate.cs:
  Open data check dialogs when the app finished laubching.

* ViewController.cs:
  Get the duplicate screeninings dialog actually working.
Create a coinciding screenings report.

* FilmInfo.cs:
  Correct region name.

* Screening.cs:
  Support finding duplicates and coinciding screenings.

* ScreeningsPlan.cs:
  Update comment.
Move duplicate screenings report to a place where it works.

* ScreeningMenuDelegate.cs:
  Stop distrusting uniqueness of screening menu items.

* AlertRaiser.cs:
  Allow saving the text in an informational alert.
Fix typo in class description.