### PR TITLE
Consider film fan availability when planning

### DIFF
--- a/PresentScreenings/Controllers/AvailabilityDialogControler.cs
+++ b/PresentScreenings/Controllers/AvailabilityDialogControler.cs
@@ -83,6 +83,9 @@ namespace PresentScreenings.TableView
         {
             base.ViewWillDisappear();
 
+            // Redraw the window title.
+            Presentor.SetWindowTitle();
+
             // Tell the app delegate we're gone.
             App.AvailabilityDialogControler = null;
 

--- a/PresentScreenings/Controllers/ViewController.cs
+++ b/PresentScreenings/Controllers/ViewController.cs
@@ -170,11 +170,6 @@ namespace PresentScreenings.TableView
             _controlByScreening = new Dictionary<Screening, ScreeningControl> { };
         }
 
-        private void SetWindowTitle()
-        {
-            View.Window.Title = $"{AppDelegate.Festival} {AppDelegate.FestivalYear} - {Plan.CurrDay:ddd d MMM}";
-        }
-
         private void DisposeColorLabels()
         {
             BlackLabel.RemoveFromSuperview();
@@ -272,6 +267,17 @@ namespace PresentScreenings.TableView
                 .Any();
 
             return fits;
+        }
+
+        public void SetWindowTitle()
+        {
+            var availableFans = ScreeningsPlan.Availabilities
+                .Where(a => a.Equals(a.FilmFan, Plan.CurrDay))
+                .Select(a => a.FilmFan)
+                .ToList();
+            string sep = ", ";
+            string available = availableFans.Count > 0 ? $"{string.Join(sep, availableFans)}" : "No fans available";
+            View.Window.Title = $"{AppDelegate.Festival} {AppDelegate.FestivalYear} - {Plan.CurrDay:ddd d MMM} - {available}";
         }
 
         public List<Screening> DayScreenings()

--- a/PresentScreenings/Controllers/ViewController.cs
+++ b/PresentScreenings/Controllers/ViewController.cs
@@ -258,6 +258,22 @@ namespace PresentScreenings.TableView
             return overlappingAttendedScreenings;
         }
 
+        public static bool ScreeningFitsAvailability(Screening screening, string fan=null)
+        {
+            // Take me as the default film fan.
+            if (fan == null)
+            {
+                fan = ScreeningInfo.Me;
+            }
+
+            // Check film fan availability at the screening's start date.
+            var fits = ScreeningsPlan.Availabilities
+                .Where(a => a.Equals(fan, screening.StartDate))
+                .Any();
+
+            return fits;
+        }
+
         public List<Screening> DayScreenings()
         {
             var dayScreenings = ScreeningsPlan.Screenings

--- a/PresentScreenings/Entities/FilmFanAvailability.cs
+++ b/PresentScreenings/Entities/FilmFanAvailability.cs
@@ -39,6 +39,11 @@ namespace PresentScreenings.TableView
         #endregion
 
         #region Override Methods
+        public override string ToString()
+        {
+            return $"{FilmFan} {AvailabilityStart:ddd yyyy-MM-dd HH:mm} - {AvailabilityEnd:ddd yyyy-MM-dd HH:mm}";
+        }
+
         public override bool ListFileIsMandatory()
         {
             return false;

--- a/PresentScreenings/Entities/FilmFanAvailability.cs
+++ b/PresentScreenings/Entities/FilmFanAvailability.cs
@@ -39,11 +39,6 @@ namespace PresentScreenings.TableView
         #endregion
 
         #region Override Methods
-        public override string ToString()
-        {
-            return $"{FilmFan} {AvailabilityStart:ddd yyyy-MM-dd HH:mm} - {AvailabilityEnd:ddd yyyy-MM-dd HH:mm}";
-        }
-
         public override bool ListFileIsMandatory()
         {
             return false;

--- a/PresentScreenings/Entities/Screening.cs
+++ b/PresentScreenings/Entities/Screening.cs
@@ -309,11 +309,12 @@ namespace PresentScreenings.TableView
             return string.Format($"{ToLongTimeString()} {Screen} {ScreeningTitle}");
         }
 
-        public string ToConsideredScreeningString()
+        public string ToConsideredScreeningString(string filmFan)
         {
-            string iAttend(bool b) => b ? "M" : string.Empty;
+            string filmFanAttends = AttendingFilmFans.Contains(filmFan) ? filmFan.Remove(1) : string.Empty;
+            //string iAttend(bool b) => b ? "M" : string.Empty;
             return string.Format($"{Film} {FilmScreeningCount} {Screen} {LongDayString(StartTime)} "
-                + $"{DurationString()} {iAttend(IAttend)} {ShortFriendsString()}");
+                + $"{DurationString()} {filmFanAttends} {ShortFriendsString()}");
         }
 
         public string DurationString()
@@ -424,7 +425,8 @@ namespace PresentScreenings.TableView
 
         private bool GetIsPlannable()
         {
-            bool plannable = TimesIAttendFilm == 0
+            bool plannable = FitsAvailability
+                && TimesIAttendFilm == 0
                 && !HasNoTravelTime
                 && !SoldOut
                 && (AppDelegate.VisitPhysical || !Location);

--- a/PresentScreenings/Entities/Screening.cs
+++ b/PresentScreenings/Entities/Screening.cs
@@ -312,7 +312,6 @@ namespace PresentScreenings.TableView
         public string ToConsideredScreeningString(string filmFan)
         {
             string filmFanAttends = AttendingFilmFans.Contains(filmFan) ? filmFan.Remove(1) : string.Empty;
-            //string iAttend(bool b) => b ? "M" : string.Empty;
             return string.Format($"{Film} {FilmScreeningCount} {Screen} {LongDayString(StartTime)} "
                 + $"{DurationString()} {filmFanAttends} {ShortFriendsString()}");
         }

--- a/PresentScreenings/Entities/Screening.cs
+++ b/PresentScreenings/Entities/Screening.cs
@@ -55,6 +55,7 @@ namespace PresentScreenings.TableView
         public bool TicketsBought { get => _screeningInfo.TicketsBought; set => _screeningInfo.TicketsBought = value; }
         public bool HasTimeOverlap => ViewController.OverlappingAttendedScreenings(this).Any();
         public bool HasNoTravelTime => ViewController.OverlappingAttendedScreenings(this, true).Any();
+        public bool FitsAvailability => ViewController.ScreeningFitsAvailability(this);
         private Screen.ScreenType ScreenType => Screen.Type;
         public bool OnLine => ScreenType == Screen.ScreenType.OnLine;
         public bool OnDemand => ScreenType == Screen.ScreenType.OnDemand;
@@ -305,15 +306,14 @@ namespace PresentScreenings.TableView
 
         public string ToPlannedScreeningString()
         {
-            return string.Format("{0} {1}", ToLongTimeString(), ScreeningTitle);
+            return string.Format($"{ToLongTimeString()} {Screen} {ScreeningTitle}");
         }
 
         public string ToConsideredScreeningString()
         {
             string iAttend(bool b) => b ? "M" : string.Empty;
-            return string.Format("{0} {1} {2} {3} {4} {5} {6}", Film, FilmScreeningCount, Screen,
-                                 LongDayString(StartTime), DurationString(), iAttend(IAttend),
-                                 ShortFriendsString());
+            return string.Format($"{Film} {FilmScreeningCount} {Screen} {LongDayString(StartTime)} "
+                + $"{DurationString()} {iAttend(IAttend)} {ShortFriendsString()}");
         }
 
         public string DurationString()

--- a/PresentScreenings/Utilities/ScreeningsPlanner.cs
+++ b/PresentScreenings/Utilities/ScreeningsPlanner.cs
@@ -46,7 +46,6 @@ namespace PresentScreenings.TableView
 
                 // Select free screenings of the selected films.
                 var screenings = ScreeningsPlan.Screenings
-                    .Where(s => s.FitsAvailability)
                     .Where(s => films.Any(f => f.FilmId == s.FilmId))
                     .Where(s => s.IsPlannable)
                     .OrderByDescending(s => s.Status == ScreeningInfo.ScreeningStatus.AttendedByFriend)
@@ -144,7 +143,7 @@ namespace PresentScreenings.TableView
             {
                 _builder.AppendLine($"Considered screenings of films rated {rating} in order:");
                 _builder.AppendLine();
-                _builder.AppendJoin(Environment.NewLine, screenings.Select(s => s.ToConsideredScreeningString()));
+                _builder.AppendJoin(Environment.NewLine, screenings.Select(s => s.ToConsideredScreeningString(filmFan)));
                 _builder.AppendLine();
             }
             else

--- a/PresentScreenings/Utilities/ScreeningsPlanner.cs
+++ b/PresentScreenings/Utilities/ScreeningsPlanner.cs
@@ -46,7 +46,9 @@ namespace PresentScreenings.TableView
 
                 // Select free screenings of the selected films.
                 var screenings = ScreeningsPlan.Screenings
-                    .Where(s => IsPlannable(s, films))
+                    .Where(s => s.FitsAvailability)
+                    .Where(s => films.Any(f => f.FilmId == s.FilmId))
+                    .Where(s => s.IsPlannable)
                     .OrderByDescending(s => s.Status == ScreeningInfo.ScreeningStatus.AttendedByFriend)
                     .ThenByDescending(s => s.Status == ScreeningInfo.ScreeningStatus.Free)
                     .ThenBy(s => s.FilmScreeningCount)
@@ -114,12 +116,6 @@ namespace PresentScreenings.TableView
         #endregion
 
         #region Private Methods
-        private bool IsPlannable(Screening screening, List<Film> films)
-        {
-            bool inSelectedFilms = films.Any(f => f.FilmId == screening.FilmId);
-            return inSelectedFilms && (screening is OnDemandScreening || screening.IsPlannable);
-        }
-
         private bool HasAttendedScreening(Film film, string filmFan)
         {
             return film.FilmScreenings.Any(s => s.FilmFanAttends(filmFan));


### PR DESCRIPTION
* ViewController.cs:
  New static method to return whether a film fan is available to
attend a screening.

* FilmFanAvailability.cs:
  Override FilmFanAvailability to ease debugging.

* Screening.cs:
  New property that indicate whether a film fan is available to attend
this screening.

* ScreeningsPlanner.cs:
  Consider film fan availability when planning automatically.