### PR TITLE
Support mutally combined films

### DIFF
--- a/FilmFestivalLoader/IFFR/parse_iffr_html.py
+++ b/FilmFestivalLoader/IFFR/parse_iffr_html.py
@@ -270,7 +270,7 @@ class ScreeningsPageParser(HtmlPageParser):
         # Set some unwanted screenings to non-public.
         if self.film.title.startswith('GLR '):
             self.audience = 'GLR'
-        elif self.film.title == 'Testing':
+        elif self.film.title == 'Testing' or self.film.title.startswith('IFFR'):
             self.audience = 'Testers'
         elif self.film.title == 'The Last Movie':
             self.audience = 'Crew'
@@ -438,7 +438,8 @@ class FilmInfoPageParser(HtmlPageParser):
     screened_film_type_by_string = {
         'Voorfilm bij ': planner.ScreenedFilmType.SCREENED_BEFORE,
         'Te zien na ': planner.ScreenedFilmType.SCREENED_AFTER,
-        'Gepresenteerd als onderdeel van ': planner.ScreenedFilmType.PART_OF_COMBINATION_PROGRAM}
+        'Gepresenteerd als onderdeel van ': planner.ScreenedFilmType.PART_OF_COMBINATION_PROGRAM,
+        'Wordt vertoond in combinatie met ': planner.ScreenedFilmType.DIRECTLY_COMBINED}
 
     def __init__(self, iffr_data, film):
         HtmlPageParser.__init__(self, iffr_data, 'FI')
@@ -506,6 +507,15 @@ class FilmInfoPageParser(HtmlPageParser):
             self.print_debug(f'COMBINATION PROGRAM INFO of {screened_film.title} UPDATED:',
                              f'\n{", ".join(str(cf) for cf in screened_film_info.combination_films)}')
 
+        # Fix zero film duration.
+        if self.film.duration.total_seconds() == 0:
+            pause = datetime.timedelta(minutes=5)
+            program_duration = (len(self.screened_films) - 1) * pause
+            for sf in self.screened_films:
+                f = self.iffr_data.get_film_from_id(sf.filmid)
+                program_duration = program_duration + f.duration
+            self.film.duration = program_duration
+
     def try_match_prefix(self, data, state_action):
         prefix_items = self.screened_film_type_by_string.items()
         for (prefix, screened_film_type) in prefix_items:
@@ -553,6 +563,26 @@ class FilmInfoPageParser(HtmlPageParser):
             return iffr_data.get_film_from_id(film_id).short_str()
 
         pr_debug(f'Main films and extras: {Globals.extras_by_main}')
+
+        # Find mutually linked films and decide which will be the main film.
+        film_ids_to_pop = set()
+        for (main_film_id, extra_infos) in Globals.extras_by_main.items():
+            if len(extra_infos) == 1:
+                (extra_film_id, screened_film_type) = extra_infos[0]
+                pairs = Globals.extras_by_main[extra_film_id]
+                if len(pairs) == 1:
+                    pair = pairs[0]
+                    if pair == (main_film_id, screened_film_type):
+                        main_duration = iffr_data.get_film_from_id(main_film_id).duration
+                        extra_duration = iffr_data.get_film_from_id(extra_film_id).duration
+                        pop_film_id = extra_film_id if main_duration > extra_duration else main_film_id
+                        film_ids_to_pop.add(pop_film_id)
+
+        # Remove the non-main films from the extras by main dictionary.
+        for film_id_to_pop in film_ids_to_pop:
+            Globals.extras_by_main.pop(film_id_to_pop)
+
+        # Implement the links in the extras by main dictionary in the film info lists,
         for (main_film_id, extra_infos) in Globals.extras_by_main.items():
             pr_debug(f'{short_str(main_film_id)} [{" || ".join([short_str(i) for (i, t) in extra_infos])}]')
             main_film = iffr_data.get_film_from_id(main_film_id)

--- a/FilmFestivalLoader/IFFR/run_iffr_unit_tests.py
+++ b/FilmFestivalLoader/IFFR/run_iffr_unit_tests.py
@@ -29,7 +29,10 @@ def main():
              append_combination_0,
              append_combination_1,
              new_screened_film_0,
-             new_screened_film_1]
+             new_screened_film_1,
+             new_screen_online,
+             new_screen_ondemand,
+             new_screen_physical]
     test_tools.execute_tests(tests)
 
 
@@ -279,6 +282,48 @@ def new_screened_film_1():
 
     # Assert.
     return screened_film.screened_film_type.name, 'SCREENED_AFTER'
+
+
+@test_tools.equity_decorator
+def new_screen_online():
+    # Arrange.
+    city = 'The Hague'
+    name = 'Online Program 42'
+    screen_type = planner_interface.Screen.screen_types[1]  # OnLine
+
+    # Act.
+    screen = TestList.festival_data.get_screen(city, name)
+
+    # Assert.
+    return screen.type, screen_type
+
+
+@test_tools.equity_decorator
+def new_screen_ondemand():
+    # Arrange.
+    city = 'The Hague'
+    name = 'On Demand Theater'
+    screen_type = planner_interface.Screen.screen_types[2]  # OnDemand
+
+    # Act.
+    screen = TestList.festival_data.get_screen(city, name)
+
+    # Assert.
+    return screen.type, screen_type
+
+
+@test_tools.equity_decorator
+def new_screen_physical():
+    # Arrange.
+    city = 'The Hague'
+    name = 'The Horse 666'
+    screen_type = planner_interface.Screen.screen_types[0]  # Physical
+
+    # Act.
+    screen = TestList.festival_data.get_screen(city, name)
+
+    # Assert.
+    return screen.type, screen_type
 
 
 if __name__ == '__main__':

--- a/FilmFestivalLoader/Shared/planner_interface.py
+++ b/FilmFestivalLoader/Shared/planner_interface.py
@@ -332,8 +332,11 @@ class FestivalData:
             self.curr_screen_id += 1
             screen_id = self.curr_screen_id
             abbr = name.replace(" ", "").lower()
+            screen_type = 'OnDemand' if abbr.startswith('ondemand')\
+                else 'OnLine' if abbr.startswith('online')\
+                else 'Location'
             print(f"NEW LOCATION:  '{city} {name}' => {abbr}")
-            screen = Screen(screen_id, city, name, abbr)
+            screen = Screen(screen_id, city, name, abbr, screen_type)
             self.screen_by_location[screen_key] = screen
         return screen
 


### PR DESCRIPTION
* parse_iffr_html.py: Exclude some test screenings.
Support directly combined films.
Fix zero duration as combination events.

* run_iffr_unit_tests.py: New unit tests for automatic typing of new
screens.

* planner_interface.py: Automatic typing of new screens.