### PR TITLE
Fix mutable default parameters

### DIFF
--- a/FilmFestivalLoader/IFFR/run_iffr_unit_tests.py
+++ b/FilmFestivalLoader/IFFR/run_iffr_unit_tests.py
@@ -225,10 +225,9 @@ def append_combination_0():
     # Arrange.
     new_film = TestList.festival_data.films[0]
     film_infos = TestList.festival_data.filminfos
-    append_combination = planner_interface.append_combination_film
 
     # Act.
-    film_infos[0].combination_films = append_combination(film_infos[0].combination_films, new_film)
+    film_infos[0].combination_films.append(new_film)
 
     # Assert.
     return len(film_infos[1].combination_films), 0
@@ -241,12 +240,11 @@ def append_combination_1():
     second_film = TestList.festival_data.films[2]
     third_film = TestList.festival_data.films[3]
     film_infos = TestList.festival_data.filminfos
-    append_combination = planner_interface.append_combination_film
 
     # Act.
-    film_infos[1].combination_films = append_combination(film_infos[1].combination_films, first_film)
-    film_infos[1].combination_films = append_combination(film_infos[1].combination_films, second_film)
-    film_infos[2].combination_films = append_combination(film_infos[2].combination_films, third_film)
+    film_infos[1].combination_films.append(first_film)
+    film_infos[1].combination_films.append(second_film)
+    film_infos[2].combination_films.append(third_film)
 
     # Assert.
     return film_infos[1].combination_films[0], first_film

--- a/FilmFestivalLoader/Shared/planner_interface.py
+++ b/FilmFestivalLoader/Shared/planner_interface.py
@@ -183,14 +183,15 @@ class ScreenedFilm:
     def __str__(self):
         return ' - '.join([str(self.filmid), self.title])
 
+
 class FilmInfo:
 
-    def __init__(self, filmid, description, article, combination_films=[], screened_films=[]):
-        self.filmid = filmid
+    def __init__(self, film_id, description, article, combination_films=None, screened_films=None):
+        self.filmid = film_id
         self.description = description
         self.article = article
-        self.combination_films = combination_films
-        self.screened_films = screened_films
+        self.combination_films = [] if combination_films is None else combination_films
+        self.screened_films = [] if screened_films is None else screened_films
 
     def __str__(self):
         combinations_str = '\nCombinations:\n' + '\n'.join([str(cf) for cf in self.combination_films])
@@ -458,25 +459,6 @@ class FestivalData:
                 for screening in public_screenings:
                     f.write(repr(screening))
         print(f"Done writing {len(public_screenings)} of {len(self.screenings)} records to {self.screenings_file}.")
-
-
-def append_combination_film(combination_films, combination_film):
-    """
-    Workaround for the bug that all combination_films seem to be referring to each other.
-
-    @param combination_films: list
-    @param combination_film: string
-    """
-    result_urls = combination_films
-    bug_fixed = False
-    if bug_fixed:
-        result_urls.append(combination_film)
-    else:
-        if len(combination_films) == 0:
-            result_urls = [combination_film]
-        else:
-            result_urls.append(combination_film)
-    return result_urls
 
 
 class Error(Exception):

--- a/PresentScreenings/Entities/Screening.cs
+++ b/PresentScreenings/Entities/Screening.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text;
 using static PresentScreenings.TableView.FilmInfo;
@@ -144,7 +143,7 @@ namespace PresentScreenings.TableView
                 string messageText = "No film found for screening";
                 string informativeText = $"Can't find film with ID={FilmId} "
                     + $"while reading {AppDelegate.ScreeningsFile}."
-                    + "\n\nFor developers: If this is caused by a URL change of the film, please"
+                    + "\n\nFor developers: If this is caused by a URL change of the film, please "
                     + "replace the filmId in ratings.csv, screenings.csv (two columns) and screeninginfo.";
                 AlertRaiser.QuitWithAlert(messageText, informativeText);
             }


### PR DESCRIPTION
* parse_iffr_html.py:
  Remove work-arounds for having a mutable as default parameter.
Readable debug info.
Stop assuming that each combination pair has a link-back pair.

* run_iffr_unit_tests.py:
  Adapt unit tests now the mutable default parameters are fixed.

* planner_interface.py:
  Fix mutable default parameters.
Remove work-around method.

* Screening.cs:
  Fix spacing in warning message.