### PR TITLE
MTMF improvements

### DIFF
--- a/FilmFestivalLoader/MTMF/parse_mtmf_html.py
+++ b/FilmFestivalLoader/MTMF/parse_mtmf_html.py
@@ -369,7 +369,8 @@ class FilmPageParser(HtmlPageParser):
                     combination_film_info.screened_films.append(screened_film)
 
             # Set the combination programs of the screened film.
-            screened_film_info.combination_films = combination_films
+            unique_combinations = set(screened_film_info.combination_films) and set(combination_films)
+            screened_film_info.combination_films = list(unique_combinations)
 
         # Link the combination programs to their screened films.
         for (film_id, screened_film_urls) in FilmPageParser.screened_film_urls_by_film_id.items():

--- a/FilmFestivalLoader/MTMF/parse_mtmf_html.py
+++ b/FilmFestivalLoader/MTMF/parse_mtmf_html.py
@@ -221,13 +221,17 @@ class FilmPageParser(HtmlPageParser):
         self.article_paragraph = ''
 
     def set_article(self):
-        self.article = '\n\n'.join(self.article_paragraphs)
+        self.article = '\n\n'.join(self.article_paragraphs).strip()
 
     def add_combination_url(self, url):
         self.combination_urls.append(url)
 
     def add_screened_film_url(self, url):
         self.screened_film_urls.append(url)
+
+    def add_properties_to_article(self):
+        properties_text = '\n'.join([f'{k}: {v}' for k, v in self.film_property_by_label.items()])
+        self.article += '\n\nFilm properties\n' + properties_text
 
     def add_film(self):
         if self.title is None:
@@ -319,6 +323,7 @@ class FilmPageParser(HtmlPageParser):
             self.set_article()
         elif self.stateStack.state_is(self.FilmsParseState.IN_PROPERTIES) and tag == 'dl':
             self.stateStack.change(self.FilmsParseState.DONE)
+            self.add_properties_to_article()
             self.add_film()
 
     def handle_data(self, data):

--- a/FilmFestivalLoader/Shared/parse_tools.py
+++ b/FilmFestivalLoader/Shared/parse_tools.py
@@ -211,7 +211,7 @@ class HtmlPageParser(BaseHtmlPageParser):
                                   audience='', program=None, display=True):
 
         screening = Screening(film, screen, start_dt, end_dt, qa, extra, audience, program, subtitles)
-        self.add_screening(screening)
+        self.add_screening(screening, display=display)
 
     def add_screening(self, screening, display=True):
 

--- a/FilmFestivalLoader/Shared/planner_interface.py
+++ b/FilmFestivalLoader/Shared/planner_interface.py
@@ -607,6 +607,25 @@ class FestivalData:
         except ValueError:
             self.curr_screen_id = 0
 
+    def print_combi_screenings(self, combi_program_id):
+        def print_screening(f, s):
+            print(f'{f.title:36} {s.start_datetime}-{s.end_datetime} {s.screen.name}')
+
+        combi_program = self.get_film_by_id(combi_program_id)
+        combi_info = combi_program.film_info(self)
+        screened_films = [self.get_film_by_id(sf.filmid) for sf in combi_info.screened_films]
+        screenings_by_title = {sf.title: sf.screenings(self) for sf in screened_films}
+        print()
+        print(f'Print the {len(combi_program.screenings(self))} screenings of {combi_program.title}, '
+              f'{len(screened_films)} screened films')
+        for cs in sorted(combi_program.screenings(self), key=lambda s: s.start_datetime):
+            print()
+            print_screening(combi_program, cs)
+            for sf in screened_films:
+                s_filtered = [s for s in screenings_by_title[sf.title] if s.start_datetime == cs.start_datetime]
+                for s in s_filtered:
+                    print_screening(sf, s)
+
     def sort_films(self):
         seq_nr = 0
         for film in sorted(self.films):

--- a/FilmFestivalLoader/Shared/planner_interface.py
+++ b/FilmFestivalLoader/Shared/planner_interface.py
@@ -263,18 +263,20 @@ class Subsection:
 
 
 class Theater:
+    default_prio = 1
 
-    def __init__(self, theater_id, city, name, abbr):
+    def __init__(self, theater_id, city, name, abbr, prio=None):
         self.theater_id = theater_id
         self.city = city
         self.name = name
         self.abbr = abbr
+        self.prio = prio or self.default_prio
 
     def __str__(self):
         return self.name
 
     def __repr__(self):
-        text = ';'.join([str(self.theater_id), self.city, self.name, self.abbr])
+        text = ';'.join([str(self.theater_id), self.city, self.name, self.abbr, self.prio])
         return f'{text}\n'
 
     def key(self):
@@ -565,7 +567,8 @@ class FestivalData:
             city = fields[1]
             name = fields[2]
             abbr = fields[3]
-            return Theater(theater_id, city, name, abbr)
+            prio = fields[4]
+            return Theater(theater_id, city, name, abbr, prio)
 
         try:
             with open(self.theaters_file, 'r') as f:

--- a/FilmFestivalLoader/Shared/planner_interface.py
+++ b/FilmFestivalLoader/Shared/planner_interface.py
@@ -32,6 +32,7 @@ def write_lists(festival_data, write_film_list, write_other_lists):
     if write_other_lists:
         festival_data.write_film_ids()
         festival_data.write_filminfo()
+        festival_data.write_theaters()
         festival_data.write_screens()
         festival_data.write_screenings()
         festival_data.write_sections()
@@ -261,13 +262,32 @@ class Subsection:
         return f'{text}\n'
 
 
+class Theater:
+
+    def __init__(self, theater_id, city, name, abbr):
+        self.theater_id = theater_id
+        self.city = city
+        self.name = name
+        self.abbr = abbr
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        text = ';'.join([str(self.theater_id), self.city, self.name, self.abbr])
+        return f'{text}\n'
+
+    def key(self):
+        return  self.city, self.name
+
+
 class Screen:
 
     screen_types = ['Location', 'OnLine', 'OnDemand']
 
-    def __init__(self, screen_id, city, name, abbr, screentype='Location'):
+    def __init__(self, screen_id, theater, name, abbr, screentype='Location'):
         self.screen_id = screen_id
-        self.city = city
+        self.theater = theater
         self.name = name
         self.abbr = abbr
         self.type = screentype
@@ -276,11 +296,11 @@ class Screen:
         return self.abbr
 
     def __repr__(self):
-        text = ";".join([str(self.screen_id), self.city, self.name, self.abbr, self.type])
+        text = ';'.join([str(self.screen_id), str(self.theater.theater_id), self.name, self.abbr, self.type])
         return f'{text}\n'
 
     def key(self):
-        return self.city, self.name
+        return self.theater.theater_id, self.name
 
 
 class Screening:
@@ -338,6 +358,7 @@ class Screening:
 
 class FestivalData:
 
+    curr_theater_id = None
     curr_screen_id = None
 
     def __init__(self, plandata_dir):
@@ -351,11 +372,14 @@ class FestivalData:
         self.section_by_id = {}
         self.subsection_by_name = {}
         self.screen_by_location = {}
+        self.theater_by_location = {}
         self.films_file = os.path.join(plandata_dir, 'films.csv')
         self.filmids_file = os.path.join(plandata_dir, 'filmids.txt')
         self.filminfo_file = os.path.join(plandata_dir, 'filminfo.xml')
         self.sections_file = os.path.join(plandata_dir, 'sections.csv')
         self.subsections_file = os.path.join(plandata_dir, 'subsections.csv')
+        self.subsections_file = os.path.join(plandata_dir, 'subsections.csv')
+        self.theaters_file = os.path.join(plandata_dir, 'theaters.csv')
         self.screens_file = os.path.join(plandata_dir, 'screens.csv')
         self.screenings_file = os.path.join(plandata_dir, 'screenings.csv')
         self.curr_film_id = None
@@ -365,6 +389,7 @@ class FestivalData:
         self.read_articles()
         self.read_sections()
         self.read_subsections()
+        self.read_theaters()
         self.read_screens()
         self.read_filmids()
 
@@ -434,8 +459,22 @@ class FestivalData:
             self.subsection_by_name[name] = subsection
         return subsection
 
-    def get_screen(self, city, name):
-        screen_key = (city, name)
+    def get_theater(self, city, name):
+        name = name if name is not None else f'{city}-Theater'
+        theater_key = (city, name)
+        try:
+            theater = self.theater_by_location[theater_key]
+        except KeyError:
+            self.curr_theater_id += 1
+            theater_id = self.curr_theater_id
+            abbr = name.replace(' ', '').lower()
+            theater = Theater(theater_id, city, name, abbr)
+            self.theater_by_location[theater_key] = theater
+        return theater
+
+    def get_screen(self, city, name, theater_name=None):
+        theater = self.get_theater(city, theater_name)
+        screen_key = (theater.theater_id, name)
         try:
             screen = self.screen_by_location[screen_key]
         except KeyError:
@@ -445,24 +484,25 @@ class FestivalData:
             screen_type = 'OnDemand' if abbr.startswith('ondemand')\
                 else 'OnLine' if abbr.startswith('online')\
                 else 'Location'
-            print(f"NEW LOCATION:  '{city} {name}' => {abbr}")
-            screen = Screen(screen_id, city, name, abbr, screen_type)
+            print(f"NEW SCREEN:  '{theater.city} {theater.name} {name}' => {abbr}")
+            screen = Screen(screen_id, theater, name, abbr, screen_type)
             self.screen_by_location[screen_key] = screen
         return screen
 
-    def splitrec(self, line, sep):
+    @staticmethod
+    def split_rec(line, sep):
         end = sep + '\r\n'
         return line.rstrip(end).split(sep)
 
     def read_articles(self):
         with open(articles_file) as f:
-            articles = [Article(self.splitrec(line, ":")) for line in f]
+            articles = [Article(self.split_rec(line, ":")) for line in f]
         Film.articles_by_language = dict([(a.key(), a) for a in articles])
 
     def read_filmids(self):
         try:
             with open(self.filmids_file, 'r') as f:
-                records = [self.splitrec(line, ';') for line in f]
+                records = [self.split_rec(line, ';') for line in f]
             for record in records:
                 film_id = int(record[0])
                 title = record[1]
@@ -482,7 +522,7 @@ class FestivalData:
     def read_sections(self):
         try:
             with open(self.sections_file, 'r') as f:
-                records = [self.splitrec(line, ';') for line in f]
+                records = [self.split_rec(line, ';') for line in f]
             for record in records:
                 section_id = int(record[0])
                 name = record[1]
@@ -501,7 +541,7 @@ class FestivalData:
     def read_subsections(self):
         try:
             with open(self.subsections_file, 'r') as f:
-                records = [self.splitrec(line, ';') for line in f]
+                records = [self.split_rec(line, ';') for line in f]
             for record in records:
                 subsection_id = int(record[0])
                 section_id = int(record[1])
@@ -519,20 +559,45 @@ class FestivalData:
         except ValueError:
             self.curr_subsection_id = 0
 
+    def read_theaters(self):
+        def create_theater(fields):
+            theater_id = int(fields[0])
+            city = fields[1]
+            name = fields[2]
+            abbr = fields[3]
+            return Theater(theater_id, city, name, abbr)
+
+        try:
+            with open(self.theaters_file, 'r') as f:
+                theaters = [create_theater(self.split_rec(line, ';')) for line in f]
+            self.theater_by_location = {theater.key(): theater for theater in theaters}
+        except OSError:
+            pass
+
+        try:
+            self.curr_theater_id = max(theater.theater_id for theater in theaters)
+        except ValueError:
+            self.curr_theater_id = 0
+
     def read_screens(self):
         def create_screen(fields):
             screen_id = int(fields[0])
-            city = fields[1]
+            theater_id = int(fields[1])
             name = fields[2]
             abbr = fields[3]
             screen_type = fields[4]
             if screen_type not in Screen.screen_types:
                 raise ScreenTypeError(abbr, screen_type)
-            return Screen(screen_id, city, name, abbr, screen_type)
+            theaters = [theater for theater in self.theater_by_location.values() if theater.theater_id == theater_id]
+            if len(theaters) == 1:
+                theater = theaters[0]
+            else:
+                raise TheaterIdError(abbr, theater_id)
+            return Screen(screen_id, theater, name, abbr, screen_type)
 
         try:
             with open(self.screens_file, 'r') as f:
-                screens = [create_screen(self.splitrec(line, ';')) for line in f]
+                screens = [create_screen(self.split_rec(line, ';')) for line in f]
             self.screen_by_location = {screen.key(): screen for screen in screens}
         except OSError:
             pass
@@ -543,10 +608,10 @@ class FestivalData:
             self.curr_screen_id = 0
 
     def sort_films(self):
-        seqnr = 0
+        seq_nr = 0
         for film in sorted(self.films):
-            seqnr += 1
-            film.seqnr = seqnr
+            seq_nr += 1
+            film.seqnr = seq_nr
 
     def screening_can_go_to_planner(self, screening):
         return screening.is_public() and not screening.film.is_part_of_combination(self)
@@ -615,6 +680,12 @@ class FestivalData:
                 f.write(repr(subsection))
         print(f'Done writing {len(self.subsection_by_name)} records to {self.subsections_file}.')
 
+    def write_theaters(self):
+        with open(self.theaters_file, 'w') as f:
+            for theater in self.theater_by_location.values():
+                f.write(repr(theater))
+        print(f'Done writing {len(self.theater_by_location)} records to {self.theaters_file}')
+
     def write_screens(self):
         with open(self.screens_file, 'w') as f:
             for screen in self.screen_by_location.values():
@@ -656,6 +727,17 @@ class ScreenTypeError(Error):
 
     def __str__(self):
         return f'Screen with abbreviation \'{self.screen_abbr}\' has unknown type: {self.screen_type}'
+
+
+class TheaterIdError(Error):
+    """Exception raised when an unknown theater ID is being processed."""
+
+    def __init__(self, screen_abbr, theater_id):
+        self.screen_abbr = screen_abbr
+        self.theater_id = theater_id
+
+    def __str__(self):
+        return f'Screen with abbreviation \'{self.screen_abbr}\' has unknown theater id: {self.theater_id}'
 
 
 if __name__ == "__main__":

--- a/FilmFestivalLoader/Shared/planner_interface.py
+++ b/FilmFestivalLoader/Shared/planner_interface.py
@@ -572,7 +572,7 @@ class FestivalData:
                 theaters = [create_theater(self.split_rec(line, ';')) for line in f]
             self.theater_by_location = {theater.key(): theater for theater in theaters}
         except OSError:
-            pass
+            theaters = []
 
         try:
             self.curr_theater_id = max(theater.theater_id for theater in theaters)

--- a/FilmFestivalLoader/Shared/web_tools.py
+++ b/FilmFestivalLoader/Shared/web_tools.py
@@ -141,10 +141,6 @@ class UrlReader:
     @classmethod
     def get_request(cls, url):
         return Request(url, headers=cls.headers)
-        # try:
-        #     return Request(url, headers=cls.headers)
-        # except ValueError as e:
-        #     self.error_collector.add(e, f'in {url}')
 
     def load_url(self, url, target_file=None, encoding=DEFAULT_ENCODING):
         request = self.get_request(url)
@@ -180,9 +176,9 @@ class HtmlCharsetParser(BaseHtmlPageParser):
         try:
             self.feed(text)
         except TypeError:
-            return 'ascii'
+            return DEFAULT_ENCODING
         else:
-            charset = (self.charset if self.charset is not None else self.default_charset)
+            charset = self.charset or self.default_charset
             return charset
 
     def handle_starttag(self, tag, attrs):

--- a/FilmFestivalLoader/Shared/web_tools.py
+++ b/FilmFestivalLoader/Shared/web_tools.py
@@ -79,6 +79,14 @@ def fix_json(code_point_str):
     return result_str
 
 
+def get_home_page(home_url, file_keeper, error_collector, debug_recorder):
+    home_file = os.path.join(file_keeper.webdata_dir, 'home.html')
+    url_file = UrlFile(home_url, home_file, error_collector, debug_recorder, byte_count=500)
+    home_html = url_file.get_text()
+    if home_html is not None:
+        print(f'Home page read into {home_file}, encoding={url_file.encoding}')
+
+
 class UrlFile:
     default_byte_count = DEFAULT_BYTE_COUNT
     default_encoding = DEFAULT_ENCODING

--- a/FilmFestivalLoader/Tests/AuxiliaryClasses/test_film.py
+++ b/FilmFestivalLoader/Tests/AuxiliaryClasses/test_film.py
@@ -1,0 +1,17 @@
+import datetime
+
+from Shared.planner_interface import Film
+
+
+class TestFilm(Film):
+    def __init__(self, film_id, title, url, minutes, description, festival_data):
+        festival_data.film_seqnr += 1
+        Film.__init__(self, festival_data.film_seqnr, film_id, title, url)
+        self.film_id = film_id
+        self.title = title
+        self.url = url
+        self.duration = datetime.timedelta(minutes=minutes)
+        self.description = description
+
+    def film_info(self, festival_data):
+        return self.film_info(festival_data)

--- a/FilmFestivalLoader/Tests/test_iffr_parser.py
+++ b/FilmFestivalLoader/Tests/test_iffr_parser.py
@@ -8,51 +8,44 @@ Created on Thu Dec 24 12:27:14 2020
 @author: maartenroos
 """
 
-import datetime
 import unittest
 
-# from IFFR.parse_iffr_html import IffrData, AzPageParser, CombinationKeeper, FilmInfoPageParser
 from IFFR.parse_iffr_html import AzPageParser, IffrData
 from Shared.application_tools import Counter
 from Shared.parse_tools import FileKeeper
 from Shared.planner_interface import Film, ScreenedFilmType, ScreenedFilm, Screen
 from Shared.web_tools import fix_json
+from Tests.AuxiliaryClasses.test_film import TestFilm
 
 festival = 'IFFR'
 festival_year = 2023
 
 
-class TestFilm():
+class IffrTestFilm(TestFilm):
     def __init__(self, film_id, title, url, minutes, description):
-        self.film_id = film_id
-        self.title = title
-        self.url = url
-        self.duration = datetime.timedelta(minutes=minutes)
-        self.description = description
-
-    def film_info(self, data):
-        return Film.film_info(self, data)
+        festival_data = arrange_festival_data()
+        TestFilm.__init__(self, film_id, title, url, minutes, description, festival_data)
 
 
 def arrange_test_films(festival_data):
     # Create a list of bare-bones film-like objects.
     test_films = []
-    test_films.append(TestFilm(
+    test_films.append(IffrTestFilm(
         500, 'Zappa',
         'https://iffr.com/nl/iffr/2021/films/4c62c61a-5d03-43f1-b3fd-1acc5fe74b2c/zappa',
         129,
         'A fabulous documentary on the greatest musical artist ever.'))
-    test_films.append(TestFilm(
+    test_films.append(IffrTestFilm(
         501, '100UP',
         'https://iffr.com/nl/iffr/2021/films/904e10e4-2b45-49ab-809a-bdac8e8950d1/100up',
         93,
         'this is test film, specially created for this unit test'))
-    test_films.append(TestFilm(
+    test_films.append(IffrTestFilm(
         502, '’Til Kingdom Come',
         'https://iffr.com/nl/iffr/2021/films/c0e65192-b1a9-4fbe-b380-c74002cee909/til-kingdom-come',
         76,
         'As the tile already indicates, the makers of the film disrespect the English language.'))
-    test_films.append(TestFilm(
+    test_films.append(IffrTestFilm(
         503, '80 000 ans',
         'https://iffr.com/nl/iffr/2021/films/80-000-ans',
         28,

--- a/FilmFestivalLoader/Tests/test_mtmf_parser.py
+++ b/FilmFestivalLoader/Tests/test_mtmf_parser.py
@@ -1,0 +1,71 @@
+import unittest
+
+from MTMF.parse_mtmf_html import FilmPageParser, MtmfData, counter
+from Shared.parse_tools import FileKeeper
+
+
+class ApplyCombinationsTestCase(unittest.TestCase):
+    def setUp(self):
+        file_keeper = FileKeeper('MTMF', 2023)
+        self.festival_data = MtmfData(file_keeper.plandata_dir)
+        self.test_films = []
+        counter.start('screened films assigned')
+        counter.start('combinations assigned')
+        self.add_test_films()
+
+    def add_test_film(self, title, minutes, url, description,
+                      subs='EN', combi_program_urls=None, combi_part_urls=None):
+        parser = FilmPageParser(self.festival_data, url)
+        parser.title = title
+        parser.film_property_by_label['Duur'] = f'{minutes} minuten'
+        parser.film_property_by_label['Ondertiteling'] = subs
+        parser.description = description
+        parser.article = ''
+        parser.combination_urls = combi_program_urls or []
+        parser.screened_film_urls = combi_part_urls or []
+        parser.add_film()
+        self.test_films.append(parser.film)
+        return parser.film
+
+    def add_test_films(self):
+        part_urls = ['https://moviesthatmatter.nl/festival/film/over-mij/',
+                     'https://moviesthatmatter.nl/festival/film/marko/']
+        self.combi_film = self.add_test_film(
+            'The Combination', 45, 'https://moviesthatmatter.nl/festival/film/under-the-lake/',
+            'This unforgettable film combines several films in one program',
+            combi_part_urls=part_urls
+        )
+        self.combi_part_1 = self.add_test_film(
+            'Parts Part 1', 20, part_urls[0],
+            'You will not find a better first part than this one',
+            combi_program_urls=[self.combi_film.url]
+        )
+        self.combi_part_2 = self.add_test_film(
+            'Parts Part 2', 18, part_urls[1],
+            'Parts Part 2 covers both zebras and aardvarks',
+            combi_program_urls=[self.combi_film.url]
+        )
+
+    def test_screened_films_linked_to_combination(self):
+        # Arrange.
+        combi_film_info = self.combi_film.film_info(self.festival_data)
+
+        # Act.
+        FilmPageParser.apply_combinations(self.festival_data)
+
+        # Assert.
+        self.assertEqual(len(combi_film_info.screened_films), 2)
+
+    def test_combination_linked_to_screened_films(self):
+        # Arrange.
+        combi_part_info = self.combi_part_1.film_info(self.festival_data)
+
+        # Act.
+        FilmPageParser.apply_combinations(self.festival_data)
+
+        # Assert.
+        self.assertEqual(len(combi_part_info.combination_films), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/PresentScreenings/AppDelegate.cs
+++ b/PresentScreenings/AppDelegate.cs
@@ -28,6 +28,7 @@ namespace PresentScreenings.TableView
         public static string WebColorsFolder => GetWebColorsPath();
         public static string ConfigFile => GetConfigFilePath();
         public static string AvailabilitiesFile { get; private set; }
+        public static string TheatersFile { get; private set; }
         public static string ScreensFile { get; private set; }
         public static string FilmsFile { get; private set; }
         public static string SectionsFile { get; private set; }
@@ -85,6 +86,7 @@ namespace PresentScreenings.TableView
 
             // Set load/unload file names.
             AvailabilitiesFile = Path.Combine(DocumentsFolder, "availabilities.csv");
+            TheatersFile = Path.Combine(DocumentsFolder, "theaters.csv");
             ScreensFile = Path.Combine(DocumentsFolder, "screens.csv");
             FilmsFile = Path.Combine(DocumentsFolder, "films.csv");
             SectionsFile = Path.Combine(DocumentsFolder, "sections.csv");

--- a/PresentScreenings/AppDelegate.cs
+++ b/PresentScreenings/AppDelegate.cs
@@ -5,7 +5,6 @@ using System.IO;
 using ObjCRuntime;
 using System.Linq;
 using YamlDotNet.Serialization.NamingConventions;
-using System.Collections.Generic;
 
 namespace PresentScreenings.TableView
 {

--- a/PresentScreenings/Controllers/AnalyserDialogController.cs
+++ b/PresentScreenings/Controllers/AnalyserDialogController.cs
@@ -95,6 +95,14 @@ namespace PresentScreenings.TableView
             _presentor.RunningPopupsCount++;
         }
 
+        public override void ViewDidAppear()
+        {
+            base.ViewDidAppear();
+
+            // Set the window title.
+            View.Window.Title = $"Analyzer, plan created for {ScreeningInfo.Me}";
+        }
+
         public override void ViewWillDisappear()
         {
             base.ViewWillDisappear();

--- a/PresentScreenings/Controllers/AvailabilityDialogControler.cs
+++ b/PresentScreenings/Controllers/AvailabilityDialogControler.cs
@@ -104,7 +104,7 @@ namespace PresentScreenings.TableView
             Presentor.DismissViewController(this);
         }
 
-        public static void SaveAvailabilities()
+        public void SaveAvailabilities()
         {
             // Save the availabilities.
             App.WriteFilmFanAvailabilities();
@@ -292,6 +292,7 @@ namespace PresentScreenings.TableView
             }
             _availablityChanged = true;
             UpdateControls(fan, true);
+            UpdateScreenings(days);
         }
 
         private void SetAvailability(NSCellStateValue state, string fan, DateTime day)
@@ -382,6 +383,15 @@ namespace PresentScreenings.TableView
                 NSButton box = boxByDay.Value;
                 box.State = AvailabilityState(fan, day);
             }
+        }
+
+        private void UpdateScreenings(List<DateTime> days)
+        {
+            List<Screening> dayScreenings = ScreeningsPlan.Screenings
+                .Where(s => days.Contains(s.StartDate))
+                .ToList();
+            Presentor.UpdateOneAttendanceStatus(ScreeningsPlan.Screenings);
+            Presentor.ReloadScreeningsView(false);
         }
 
         private NSCellStateValue AvailabilityState(string fan)

--- a/PresentScreenings/Controllers/ViewController.cs
+++ b/PresentScreenings/Controllers/ViewController.cs
@@ -310,6 +310,10 @@ namespace PresentScreenings.TableView
             {
                 screening.Status = ScreeningInfo.ScreeningStatus.NoTravelTime;
             }
+            else if (!screening.FitsAvailability)
+            {
+                screening.Status = ScreeningInfo.ScreeningStatus.Unavailable;
+            }
             else
             {
                 screening.Status = ScreeningInfo.ScreeningStatus.Free;

--- a/PresentScreenings/Controllers/WarningsDialogControler.cs
+++ b/PresentScreenings/Controllers/WarningsDialogControler.cs
@@ -69,9 +69,9 @@ namespace PresentScreenings.TableView
 
         #region Constructors
         public WarningsDialogControler (IntPtr handle) : base (handle)
-		{
+        {
             LabelByScreening = new Dictionary<Screening, NSView> { };
-		}
+        }
         #endregion
 
         #region Override Methods

--- a/PresentScreenings/Entities/Configuration.cs
+++ b/PresentScreenings/Entities/Configuration.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.IO;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace PresentScreenings.TableView
 {

--- a/PresentScreenings/Entities/Screen.cs
+++ b/PresentScreenings/Entities/Screen.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace PresentScreenings.TableView
@@ -31,6 +32,7 @@ namespace PresentScreenings.TableView
 
         #region Properties
         public int ScreenId { get; }
+        public Theater Theater { get; }
         public string City { get; }
         public string ParseName { get; }
         public string Abbreviation { get; }
@@ -56,14 +58,17 @@ namespace PresentScreenings.TableView
         {
             // Assign the fields of the input string.
             string[] fields = screenText.Split(';');
-            string screenId = fields[0];
-            City = fields[1];
+            string screenIdString = fields[0];
+            string theaterIdString = fields[1];
             ParseName = fields[2];
             Abbreviation = fields[3];
             string screenType = fields[4];
 
             // Assign properties that need calculating.
-            ScreenId = int.Parse(screenId);
+            ScreenId = int.Parse(screenIdString);
+            int theaterId = int.Parse(theaterIdString);
+            Theater = (from Theater t in ScreeningsPlan.Theaters where t.TheaterId == theaterId select t).First();
+            City = Theater.City;
             Type = (ScreenType)Enum.Parse(typeof(ScreenType), screenType);
         }
 

--- a/PresentScreenings/Entities/Screening.cs
+++ b/PresentScreenings/Entities/Screening.cs
@@ -63,6 +63,7 @@ namespace PresentScreenings.TableView
         public bool Location => ScreenType == Screen.ScreenType.Location;
         public int TimesIAttendFilm => ScreeningsPlan.Screenings.Count(s => s.FilmId == FilmId && s.IAttend);
         public bool IsPlannable => GetIsPlannable();
+        public bool HasEligibleTheater => GetHasEligibleTheater();
         public List<Screening> FilmScreenings => ViewController.FilmScreenings(FilmId);
         public int FilmScreeningCount => FilmScreenings.Count;
         public List<ScreenedFilm> ScreenedFilms => Film.FilmInfo.ScreenedFilms;
@@ -250,6 +251,12 @@ namespace PresentScreenings.TableView
                 && !SoldOut
                 && (AppDelegate.VisitPhysical || !Location);
             return plannable;
+        }
+
+        protected virtual bool GetHasEligibleTheater()
+        {
+            Theater.PriorityValue priority = Screen.Theater.Priority;
+            return priority == Theater.PriorityValue.High;
         }
         #endregion
 

--- a/PresentScreenings/Entities/ScreeningInfo.cs
+++ b/PresentScreenings/Entities/ScreeningInfo.cs
@@ -15,6 +15,7 @@ namespace PresentScreenings.TableView
         public enum ScreeningStatus
         {
             Free,
+            Unavailable,
             Attending,
             AttendedByFriend,
             AttendingFilm,
@@ -78,6 +79,7 @@ namespace PresentScreenings.TableView
         {
             _screeningStatusByString = new Dictionary<string, ScreeningStatus> { };
             _screeningStatusByString.Add("ONWAAR", ScreeningStatus.Free);
+            _screeningStatusByString.Add("AFWEZIG", ScreeningStatus.Unavailable);
             _screeningStatusByString.Add("MAARTEN", ScreeningStatus.Attending);
             _screeningStatusByString.Add("FILM", ScreeningStatus.AttendingFilm);
             _screeningStatusByString.Add("TIJD", ScreeningStatus.TimeOverlap);

--- a/PresentScreenings/Entities/ScreeningsPlan.cs
+++ b/PresentScreenings/Entities/ScreeningsPlan.cs
@@ -22,6 +22,7 @@ namespace PresentScreenings.TableView
 
         #region Static Properties
         public static List<FilmFanAvailability> Availabilities { get; private set; }
+        public static List<Theater> Theaters { get; private set; }
         public static List<Screen> Screens { get; private set; }
         public static List<Film> Films { get; private set; }
         public static List<Section> Sections { get; private set; }
@@ -47,6 +48,10 @@ namespace PresentScreenings.TableView
             // Read availability.
             Availabilities = new FilmFanAvailability()
                 .ReadListFromFile(AppDelegate.AvailabilitiesFile, line => new FilmFanAvailability(line));
+
+            // Read theaters.
+            Theaters = new Theater()
+                .ReadListFromFile(AppDelegate.TheatersFile, line => new Theater(line));
 
             // Read screens.
             Screens = new Screen()

--- a/PresentScreenings/Entities/Theater.cs
+++ b/PresentScreenings/Entities/Theater.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace PresentScreenings.TableView
 {
@@ -20,9 +19,19 @@ namespace PresentScreenings.TableView
         public string Name { get; }
         public string Abbreviation { get; }
         public PriorityValue Priority { get; private set; }
+        public static Dictionary<int, PriorityValue> PriorityByNumber { get; set; }
         #endregion
 
         #region Constructors
+        // Static constructor.
+        static Theater()
+        {
+            PriorityByNumber = new Dictionary<int, PriorityValue> { };
+            PriorityByNumber.Add(0, PriorityValue.NoGo);
+            PriorityByNumber.Add(1, PriorityValue.Low);
+            PriorityByNumber.Add(2, PriorityValue.High);
+        }
+
         // Constructor to read records from the interface file.
         public Theater(string theaterText)
         {
@@ -32,20 +41,11 @@ namespace PresentScreenings.TableView
             City = fields[1];
             Name = fields[2];
             Abbreviation = fields[3];
+            string priorityString = fields[4];
 
             // Assign properties that need calculating.
             TheaterId = int.Parse(theaterId);
-
-            // EXPRIMENT introduce priority.
-            List<int> eligibleTheaters = new List<int> { 1, 15 };
-            if (eligibleTheaters.Contains(TheaterId))
-            {
-                Priority = PriorityValue.High;
-            }
-            else
-            {
-                Priority = PriorityValue.Low;
-            }
+            Priority = PriorityByNumber[int.Parse(priorityString)];
         }
 
         // Empty constructor to facilitate ListStreamer method calls.

--- a/PresentScreenings/Entities/Theater.cs
+++ b/PresentScreenings/Entities/Theater.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PresentScreenings.TableView
+{
+    public class Theater : ListStreamer
+    {
+        #region Public Members
+        public enum PriorityValue
+        {
+            NoGo,
+            Low,
+            High,
+        }
+        #endregion
+
+        #region Properties
+        public int TheaterId { get; }
+        public string City { get; }
+        public string Name { get; }
+        public string Abbreviation { get; }
+        public PriorityValue Priority { get; private set; }
+        #endregion
+
+        #region Constructors
+        // Constructor to read records from the interface file.
+        public Theater(string theaterText)
+        {
+            // Assign the fields of the input string.
+            string[] fields = theaterText.Split(';');
+            string theaterId = fields[0];
+            City = fields[1];
+            Name = fields[2];
+            Abbreviation = fields[3];
+
+            // Assign properties that need calculating.
+            TheaterId = int.Parse(theaterId);
+
+            // EXPRIMENT introduce priority.
+            List<int> eligibleTheaters = new List<int> { 1, 15 };
+            if (eligibleTheaters.Contains(TheaterId))
+            {
+                Priority = PriorityValue.High;
+            }
+            else
+            {
+                Priority = PriorityValue.Low;
+            }
+        }
+
+        // Empty constructor to facilitate ListStreamer method calls.
+        public Theater() { }
+        #endregion
+
+        #region Override Methods
+        public override bool ListFileHasHeader()
+        {
+            return false;
+        }
+
+        public override string ToString()
+        {
+            return $"{Name} {City}";
+        }
+        #endregion
+    }
+}

--- a/PresentScreenings/PresentScreenings.csproj
+++ b/PresentScreenings/PresentScreenings.csproj
@@ -196,6 +196,7 @@
       <DependentUpon>WarningsDialogControler.cs</DependentUpon>
     </Compile>
     <Compile Include="Entities\Configuration.cs" />
+    <Compile Include="Entities\Theater.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Main.storyboard" />

--- a/PresentScreenings/Utilities/ScreeningsPlanner.cs
+++ b/PresentScreenings/Utilities/ScreeningsPlanner.cs
@@ -49,6 +49,7 @@ namespace PresentScreenings.TableView
                 var screenings = ScreeningsPlan.Screenings
                     .Where(s => films.Any(f => f.FilmId == s.FilmId))
                     .Where(s => s.IsPlannable)
+                    .Where(s => s.HasEligibleTheater)
                     .OrderByDescending(s => s.Status == ScreeningInfo.ScreeningStatus.AttendedByFriend)
                     .ThenByDescending(s => s.Status == ScreeningInfo.ScreeningStatus.Free)
                     .ThenByDescending(s => s.HasQAndA)

--- a/PresentScreenings/Views/ColorView.cs
+++ b/PresentScreenings/Views/ColorView.cs
@@ -48,6 +48,8 @@ namespace PresentScreenings.TableView
         #region Private members
         private static readonly NSColor screeningBgColorBlack = NSColor.FromRgb(0, 0, 0);
         private static readonly NSColor screeningTextColorBlack = NSColor.White;
+        private static readonly NSColor screeningBgColorOffBlack = NSColor.FromRgb(38, 38, 38);
+        private static readonly NSColor screeningTextColorOffBlack = NSColor.Orange;
         private static readonly NSColor screeningBgColorGrey = NSColor.FromRgb(219, 219, 219);
         private static readonly NSColor screeningTextColorGrey = NSColor.FromRgb(0, 0, 0);
         private static readonly NSColor screeningBgColorDarkGrey = NSColor.FromRgb(176, 176, 176);
@@ -96,6 +98,7 @@ namespace PresentScreenings.TableView
 
             TextColorByScreeningStatus = new Dictionary<ScreeningInfo.ScreeningStatus, NSColor> { };
             TextColorByScreeningStatus.Add(ScreeningInfo.ScreeningStatus.Free, screeningTextColorBlack);
+            TextColorByScreeningStatus.Add(ScreeningInfo.ScreeningStatus.Unavailable, screeningTextColorOffBlack);
             TextColorByScreeningStatus.Add(ScreeningInfo.ScreeningStatus.NeedingTickets, screeningTextColorPurple);
             TextColorByScreeningStatus.Add(ScreeningInfo.ScreeningStatus.Attending, screeningTextColorRed);
             TextColorByScreeningStatus.Add(ScreeningInfo.ScreeningStatus.AttendedByFriend, screeningTextColorBlue);
@@ -105,6 +108,7 @@ namespace PresentScreenings.TableView
 
             BgColorByScreeningStatus = new Dictionary<ScreeningInfo.ScreeningStatus, NSColor> { };
             BgColorByScreeningStatus.Add(ScreeningInfo.ScreeningStatus.Free, screeningBgColorBlack);
+            BgColorByScreeningStatus.Add(ScreeningInfo.ScreeningStatus.Unavailable, screeningBgColorOffBlack);
             BgColorByScreeningStatus.Add(ScreeningInfo.ScreeningStatus.NeedingTickets, screeningBgColorPurple);
             BgColorByScreeningStatus.Add(ScreeningInfo.ScreeningStatus.Attending, screeningBgColorRed);
             BgColorByScreeningStatus.Add(ScreeningInfo.ScreeningStatus.AttendedByFriend, screeningBgColorBlue);

--- a/Tools/compare_planner_data.sh
+++ b/Tools/compare_planner_data.sh
@@ -8,6 +8,7 @@ declare -r files="
     screens.csv
     sections.csv
     subsections.csv
+    theaters.csv
     filminfo.xml
 "
 declare -r film_file=films.csv


### PR DESCRIPTION
PresentScreenings/AppDelegate.cs, PresentScreenings/Entities/Screen.cs, PresentScreenings/Views/ColorView.cs, PresentScreenings/Entities/Theater.cs, PresentScreenings/Entities/Screening.cs, PresentScreenings/PresentScreenings.csproj, PresentScreenings/Entities/ScreeningsPlan.cs, FilmFestivalLoader/Shared/planner_interface.py, PresentScreenings/Utilities/ScreeningsPlanner.cs:
  Support theaters.

FilmFestivalLoader/MTMF/parse_mtmf_html.py:
  Switch to the 2023 edition.
Utilise the shared parse tools.
Utilise the shared application tools.
Expand the shared web tools.
Read films.
Read screenings.
Refactor imports.
Work in progress: leave commented out code for moving to tools or parsing combinations.

FilmFestivalLoader/Shared/web_tools.py:
  New get_netloc() function.
Catch more errors.

PresentScreenings/Entities/ScreeningInfo.cs, PresentScreenings/Controllers/ViewController.cs, PresentScreenings/Controllers/AvailabilityDialogControler.cs:
  Support screening status Unavailable.

PresentScreenings/Controllers/WarningsDialogControler.cs:
  Tickets Bought checkboxes in Warnings dialog.