### PR TITLE
Use screen ID

### DIFF
--- a/FilmFestivalLoader/Shared/planner_interface.py
+++ b/FilmFestivalLoader/Shared/planner_interface.py
@@ -287,12 +287,12 @@ class Screen:
 
     screen_types = ['Location', 'OnLine', 'OnDemand']
 
-    def __init__(self, screen_id, theater, name, abbr, screentype='Location'):
+    def __init__(self, screen_id, theater, name, abbr, screen_type='Location'):
         self.screen_id = screen_id
         self.theater = theater
         self.name = name
         self.abbr = abbr
-        self.type = screentype
+        self.type = screen_type
 
     def __str__(self):
         return self.abbr
@@ -330,11 +330,11 @@ class Screening:
     @staticmethod
     def screening_repr_csv_head():
         text = ";".join([
-            "filmid",
-            "screen",
-            "starttime",
-            "endtime",
-            "combinationid",
+            "film_id",
+            "screen_id",
+            "start_time",
+            "end_time",
+            "combination_id",
             "subtitles",
             "qanda",
             "extra",
@@ -344,7 +344,7 @@ class Screening:
     def __repr__(self):
         text = ";".join([
             str(self.film.filmid),
-            self.screen.abbr,
+            str(self.screen.screen_id),
             self.start_datetime.isoformat(sep=' '),
             self.end_datetime.isoformat(sep=' '),
             str(self.combination_program.filmid if self.combination_program is not None else ''),

--- a/FilmFestivalLoader/Tests/test_planner_interface.py
+++ b/FilmFestivalLoader/Tests/test_planner_interface.py
@@ -1,7 +1,7 @@
 import tempfile
 import unittest
 
-from Shared.planner_interface import FestivalData, Section
+from Shared.planner_interface import FestivalData, Section, Screen
 
 
 class SectionsTestCase(unittest.TestCase):
@@ -47,6 +47,33 @@ class SectionsTestCase(unittest.TestCase):
 
         # Assert.
         self.assertEqual(len(data.section_by_name), 2)
+
+
+class ScreensTestCase(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.festival_data = FestivalData(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_screens_can_be_read(self):
+        # Arrange.
+        data = self.festival_data
+        city = 'Amsterdam'
+        theater_name = 'Kriterion'
+        screen_1 = data.get_screen(city, 'Kriterion Grote Zaal', theater_name)
+        screen_2 = data.get_screen(city, 'Kriterion Kleine Zaal', theater_name)
+        screen_1.abbr = 'krgr'
+        screen_2.abbr = 'krkl'
+        data.write_screens()
+
+        # Act.
+        data.read_screens()
+
+        # Assert.
+        self.assertEqual(len(data.screen_by_location), 2)
+        self.assertEqual(len(data.theater_by_location), 1)
 
 
 if __name__ == '__main__':

--- a/PresentScreenings/Controllers/ViewController.cs
+++ b/PresentScreenings/Controllers/ViewController.cs
@@ -601,6 +601,11 @@ namespace PresentScreenings.TableView
             return ScreeningsPlan.Films.First(f => f.FilmId == filmId);
         }
 
+        public static Screen GetScreenById(int screenId)
+        {
+            return ScreeningsPlan.Screens.First(s => s.ScreenId == screenId);
+        }
+
         public static FilmInfo GetFilmInfo(int filmId)
         {
             var info = ScreeningsPlan.FilmInfos.Where(f => f.FilmId == filmId).ToList();

--- a/PresentScreenings/Entities/Screening.cs
+++ b/PresentScreenings/Entities/Screening.cs
@@ -89,7 +89,7 @@ namespace PresentScreenings.TableView
             IndexByName = new Dictionary<string, int> { };
             int n = 0;
             IndexByName.Add("FilmId", n);
-            IndexByName.Add("Screen", ++n);
+            IndexByName.Add("ScreenId", ++n);
             IndexByName.Add("StartTime", ++n);
             IndexByName.Add("EndTime", ++n);
             IndexByName.Add("CombinationProgramId", ++n);
@@ -105,7 +105,7 @@ namespace PresentScreenings.TableView
             // Assign the fields of the input string.
             string[] fields = screeningText.Split(';');
             int filmId = int.Parse(fields[IndexByName["FilmId"]]);
-            string screen = fields[IndexByName["Screen"]];
+            int screenId = int.Parse(fields[IndexByName["ScreenId"]]);
             string startTimeString = fields[IndexByName["StartTime"]];
             string endTimeString = fields[IndexByName["EndTime"]];
             string combinationIdStr = fields[IndexByName["CombinationProgramId"]];
@@ -115,7 +115,7 @@ namespace PresentScreenings.TableView
 
             // Assign key properties.
             OriginalFilmId = filmId;
-            Screen = (from Screen s in ScreeningsPlan.Screens where s.ToString() == screen select s).First();
+            Screen = ViewController.GetScreenById(screenId);
             DateTime startTime = DateTime.Parse(startTimeString);
             DateTime endTime = DateTime.Parse(endTimeString);
 

--- a/PresentScreenings/Entities/ScreeningInfo.cs
+++ b/PresentScreenings/Entities/ScreeningInfo.cs
@@ -106,7 +106,7 @@ namespace PresentScreenings.TableView
             // Parse the fields of the input string.
             string[] fields = ScreeningInfoText.Split(';');
             OriginalFilmId = int.Parse(fields[0]);
-            string screen = fields[1];
+            int screenId = int.Parse(fields[1]);
             StartTime = DateTime.Parse(fields[2]);
             MovableStartTime = DateTime.Parse(fields[3]);
             MovableEndTime = DateTime.Parse(fields[4]);
@@ -118,7 +118,7 @@ namespace PresentScreenings.TableView
             string soldOut = fields[10];
 
             // Assign properties.
-            Screen = ScreeningsPlan.Screens.First(s => s.ToString() == screen);
+            Screen = ViewController.GetScreenById(screenId);
             AutomaticallyPlanned = StringToBool[automaticallyPlanned];
             Attendees = GetAttendeesFromStrings(attendanceStrings);
             TicketsBought = StringToBool[ticketsBought];
@@ -147,7 +147,7 @@ namespace PresentScreenings.TableView
 
         public override string WriteHeader()
         {
-            string headerFmt = "filmid;screen;starttime;movablestarttime;movableendtime;combinedfilmid;autoplanned;blocked;{0};ticketsbought;soldout";
+            string headerFmt = "filmid;screenid;starttime;movablestarttime;movableendtime;combinedfilmid;autoplanned;blocked;{0};ticketsbought;soldout";
             return string.Format(headerFmt, FilmFansString());
         }
 
@@ -156,7 +156,7 @@ namespace PresentScreenings.TableView
             string line = string.Join(
                 ';',
                 OriginalFilmId,
-                Screen,
+                Screen.ScreenId,
                 StartTime.ToString(_dateTimeFormat),
                 MovableStartTime.ToString(_dateTimeFormat),
                 MovableEndTime.ToString(_dateTimeFormat),

--- a/PresentScreenings/Entities/ScreeningsPlan.cs
+++ b/PresentScreenings/Entities/ScreeningsPlan.cs
@@ -244,10 +244,8 @@ namespace PresentScreenings.TableView
         {
             // Parse the screen from the input line.
             string[] fields = line.Split(';');
-            string screenString = fields[Screening.IndexByName["Screen"]];
-            Screen screen = Screens
-                .Where(s => s.Abbreviation == screenString)
-                .First();
+            int screenId = int.Parse(fields[Screening.IndexByName["ScreenId"]]);
+            Screen screen = ViewController.GetScreenById(screenId);
 
             // Return the Screening or subclass, dependent of the screen type.
             return screen.Type == Screen.ScreenType.OnLine ? new OnLineScreening(line)


### PR DESCRIPTION
* planner_interface.py: Write screenings with screen ID, not abbreviation. Improve naming.

* test_planner_interface.py: Add a test concerning screens.

* ScreeningsPlan.cs, ViewController.cs: New method to get a screen from the list.

* Screening.cs: Expect screen ID, not abbreviation, when reading screenings.

* ScreeningInfo.cs: Write screen ID, not abbreviation, when writing screening info. Expect screen ID, not abbreviation, when reading screening info.