### PR TITLE
Support Imagine 2023

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 __init__.py
 .vs/
 mono_crash.*
+FilmRatings/
 PresentScreenings/bin/
 PresentScreenings/obj/
 packages/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml

--- a/FestivalPlanner/loader/views.py
+++ b/FestivalPlanner/loader/views.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from django.views import View
 from django.views.generic import FormView, ListView
 
-from festival_planner.tools import add_base_context, get_log, unset_log, initialize_log
+from festival_planner.tools import add_base_context, get_log, unset_log, initialize_log, pr_debug
 from festivals.models import Festival
 from films.models import Film, FilmFanFilmRating
 from loader.forms.loader_forms import SectionLoader, SubsectionLoader, RatingLoaderForm, TheaterDataLoaderForm, \
@@ -130,12 +130,13 @@ class NewTheaterDataListView(ListView):
         return context
 
     def get_new_screen_item(self, screen):
+        theater_kwargs = {'city': screen.theater.city, 'abbreviation': screen.theater.abbreviation}
         new_screen_item = {
             'city': screen.theater.city.name,
             'city_color': self.color(City, City.cities, **{'country': 'nl', 'name': screen.theater.city.name}),
             'theater': screen.theater.parse_name,
             'theater_abbr': screen.theater.abbreviation,
-            'theater_color': self.color(Theater, Theater.theaters, **{'parse_name': screen.theater.parse_name}),
+            'theater_color': self.color(Theater, Theater.theaters, **theater_kwargs),
             'screen': screen.parse_name,
             'screen_abbr': screen.abbreviation,
             'address_type': screen.address_type.label,
@@ -232,6 +233,7 @@ class SectionsLoaderView(LoginRequiredMixin, ListView):
     template_name = 'loader/sections.html'
     http_method_names = ['get', 'post']
     object_list = [get_festival_row(festival) for festival in Festival.festivals.order_by('-start_date')]
+    queryset = object_list
     context_object_name = 'festival_rows'
     unexpected_error = ''
 

--- a/FestivalPlanner/templates/films/films.html
+++ b/FestivalPlanner/templates/films/films.html
@@ -52,8 +52,7 @@
         {% else %}
             changed rating {{ action.old_rating }} of <a href="{% url 'films:results' action.rated_film_id %}">{{ action.rated_film }}</a> into <em> {{ action.new_rating }} ({{ action.new_rating_name }})</em>
         {% endif %}
-        {% now "Y-m-d H:i:s" as the_time %}
-        {% if the_time <= action.action_time|date:"Y-m-d H:i:s" %}
+        {% if action.action_time|timesince == "0 minutes" %}
             less than a minute ago
         {% else %}
             {{ action.action_time|timesince }} ago

--- a/FilmFestivalLoader/Imagine/parse_imagine_html.py
+++ b/FilmFestivalLoader/Imagine/parse_imagine_html.py
@@ -64,7 +64,7 @@ def get_details_of_all_films(festival_data):
 
 def get_details_of_one_film(festival_data, film):
     film_file = fileKeeper.film_webdata_file(film.filmid)
-    url_file = UrlFile(film.url, film_file, error_collector, debug_recorder, byte_count=30000)
+    url_file = UrlFile(film.url, film_file, error_collector, debug_recorder, byte_count=256)
     film_html = url_file.get_text(f'Downloading site of {film.title}: {film.url}')
 
     if film_html is not None:

--- a/FilmFestivalLoader/Imagine/parse_imagine_html.py
+++ b/FilmFestivalLoader/Imagine/parse_imagine_html.py
@@ -17,8 +17,8 @@ from Shared.web_tools import UrlFile
 
 # Parameters.
 festival = 'Imagine'
-year = 2022
-city = 'Amsterdam'
+year = 2023
+festival_city = 'Amsterdam'
 ondemand_available_hours = None
 
 # Files.
@@ -51,7 +51,7 @@ def parse_imagine_sites(festival_data):
 
 def get_films(festival_data):
     az_url = imagine_hostname + az_url_path
-    url_file = UrlFile(az_url, az_file, error_collector, byte_count=100)
+    url_file = UrlFile(az_url, az_file, error_collector, debug_recorder, byte_count=100)
     az_html = url_file.get_text()
     if az_html is not None:
         AzPageParser(festival_data).feed(az_html)
@@ -64,7 +64,7 @@ def get_details_of_all_films(festival_data):
 
 def get_details_of_one_film(festival_data, film):
     film_file = fileKeeper.film_webdata_file(film.filmid)
-    url_file = UrlFile(film.url, film_file, error_collector, byte_count=30000)
+    url_file = UrlFile(film.url, film_file, error_collector, debug_recorder, byte_count=30000)
     film_html = url_file.get_text(f'Downloading site of {film.title}: {film.url}')
 
     if film_html is not None:
@@ -85,21 +85,25 @@ class AzPageParser(HtmlPageParser):
         IN_LANGUAGE = auto()
         IN_DURATION = auto()
 
+    num_screen_re = re.compile(r'^(?P<theater>.*?) (?P<number>\d+)$')
+
     def __init__(self, festival_data):
-        HtmlPageParser.__init__(self, festival_data, debug_recorder, 'AZ')
-        self.debugging = True
+        HtmlPageParser.__init__(self, festival_data, debug_recorder, 'AZ', debugging=True)
+        self.sorting_from_site = False
         self.film = None
         self.url = None
         self.title = None
         self.sort_title = None
         self.duration = None
-        self.section = None
+        self.section_name = None
+        self.section_color = None
         self.screen_name = None
         self.screen = None
         self.start_dt = None
         self.end_dt = None
         self.medium_type = None
         self.audience = None
+        self.qa = None
         self.subtitles = None
         self.stateStack = self.StateStack(self.print_debug, self.AzParseState.IDLE)
         self.init_categories()
@@ -111,6 +115,7 @@ class AzPageParser(HtmlPageParser):
         Film.category_by_string['Feature'] = Film.category_films
         Film.category_by_string['Shorts'] = Film.category_combinations
         Film.category_by_string['Special'] = Film.category_events
+        Film.category_by_string['Talk'] = Film.category_events
         Film.category_by_string['Workshop'] = Film.category_events
 
     def init_screening_data(self):
@@ -119,13 +124,15 @@ class AzPageParser(HtmlPageParser):
         self.title = None
         self.sort_title = None
         self.duration = None
-        self.section = None
+        self.section_name = None
+        self.section_color = None
         self.screen_name = None
         self.screen = None
         self.start_dt = None
         self.end_dt = None
         self.medium_type = None
         self.audience = 'publiek'
+        self.qa = ''
         self.subtitles = ''
 
     @staticmethod
@@ -135,9 +142,45 @@ class AzPageParser(HtmlPageParser):
         return duration
 
     def get_screen(self, data):
-        screen_name = data.strip()
-        screen = self.festival_data.get_screen(city, screen_name)
+        screen_parse_name = data.strip()
+        city_name, theater_parse_name, screen_abbreviation = self.split_location(screen_parse_name)
+        screen = self.festival_data.get_screen(
+            city_name,
+            screen_parse_name,
+            theater_parse_name=theater_parse_name,
+            screen_abbreviation=screen_abbreviation
+        )
         return screen
+
+    def split_location(self, location):
+        city_name = festival_city
+        theater_parse_name = location
+        default_screen_abbreviation = 'zaal'
+        num_match = self.num_screen_re.match(location)
+        if location.startswith('KINO'):
+            city_name = 'Rotterdam'
+        if location == 'SPUI 25':
+            theater_parse_name = location
+            screen_abbreviation = default_screen_abbreviation
+        elif location == 'OBA Oosterdok OBA Theater':
+            location_words = location.split()
+            theater_parse_name = ' '.join(location_words[:2])
+            screen_abbreviation = ' '.join(location_words[2:])
+        elif num_match:
+            theater_parse_name = num_match.group(1)
+            screen_abbreviation = num_match.group(2)
+        elif location.startswith('LAB111 '):
+            theater_parse_name = 'LAB111'
+            screen_abbreviation = location.split()[1]
+        else:
+            screen_abbreviation = default_screen_abbreviation
+        return city_name, theater_parse_name, screen_abbreviation
+
+    def get_title(self, data):
+        qa_string = ' + Q&A'
+        self.qa = 'Q&A' if data.endswith(qa_string) else ''
+        title = data[:-len(qa_string)] if self.qa else data
+        return title
 
     @staticmethod
     def get_subtitles(data):
@@ -153,20 +196,25 @@ class AzPageParser(HtmlPageParser):
             error_collector.add(f'Could not create film:', '{self.title} ({self.url})')
         else:
             # Fill details.
-            if self.section is None:
-                self.section = 'Imagine General'
-            self.film.subsection = self.festival_data.subsection_by_name[self.section]
-            if self.section == 'Industry':
-                self.audience = 'industry'
-            self.film.medium_category = self.medium_type
-            self.film.sortstring = self.sort_title
             self.film.duration = self.duration
+            self.film.subsection = self.get_subsection()
+            self.film.medium_category = self.medium_type
+            if self.sorting_from_site:
+                self.film.sortstring = self.sort_title
 
             # Add the film to the list.
             self.festival_data.films.append(self.film)
 
             # Get the film info.
             get_details_of_one_film(self.festival_data, self.film)
+
+    def get_subsection(self):
+        if self.section_name:
+            section = self.festival_data.get_section(self.section_name, self.section_color)
+            dummy_url = 'https://www.imaginefilmfestival.nl/en/blockschedule'
+            subsection = self.festival_data.get_subsection(section.name, dummy_url, section)
+            return subsection
+        return None
 
     def add_imagine_screening(self):
         # Get the film.
@@ -182,8 +230,13 @@ class AzPageParser(HtmlPageParser):
         self.end_dt = self.start_dt + duration
 
         # Add screening to the list.
-        HtmlPageParser.add_screening_from_fields(self, self.film, self.screen, self.start_dt, self.end_dt,
-                                                 audience=self.audience, subtitles=self.subtitles, display=True)
+        HtmlPageParser.add_screening_from_fields(
+            self,
+            self.film,
+            self.screen,
+            self.start_dt,
+            self.end_dt,
+            qa=self.qa, audience=self.audience, subtitles=self.subtitles, display=True)
 
         # Initialize the next round of parsing.
         self.init_screening_data()
@@ -204,6 +257,9 @@ class AzPageParser(HtmlPageParser):
                 self.start_dt = datetime.datetime.fromisoformat(attrs[0][1])
         elif self.stateStack.state_is(self.AzParseState.IN_SCREENING) and tag == 'section':
             self.stateStack.push(self.AzParseState.IN_SECTION)
+        elif self.stateStack.state_is(self.AzParseState.IN_SECTION) and tag == 'div' and len(attrs):
+            if attrs[0][1].startswith('background-color'):
+                self.section_color = attrs[0][1].split(':')[1]
         elif self.stateStack.state_is(self.AzParseState.IN_SCREENING) and tag == 'div' and len(attrs) > 0:
             if attrs[0][1] == 'type':
                 self.stateStack.push(self.AzParseState.IN_TYPE)
@@ -228,13 +284,13 @@ class AzPageParser(HtmlPageParser):
         HtmlPageParser.handle_data(self, data)
 
         if self.stateStack.state_is(self.AzParseState.IN_SECTION):
-            self.section = data
+            self.section_name = data
             self.stateStack.pop()
         if self.stateStack.state_is(self.AzParseState.IN_TYPE):
             self.medium_type = data
             self.stateStack.pop()
         elif self.stateStack.state_is(self.AzParseState.IN_TITLE):
-            self.title = data
+            self.title = self.get_title(data)
             self.stateStack.pop()
         elif self.stateStack.state_is(self.AzParseState.IN_SCREEN):
             self.screen = self.get_screen(data)
@@ -264,8 +320,7 @@ class FilmPageParser(HtmlPageParser):
         DONE = auto()
 
     def __init__(self, festival_data, film):
-        HtmlPageParser.__init__(self, festival_data, debug_recorder, "F")
-        self.debugging = False
+        HtmlPageParser.__init__(self, festival_data, debug_recorder, "F", debugging=True)
         self.film = film
         self.description = None
         self.alt_description = None
@@ -402,7 +457,7 @@ class ImagineData(FestivalData):
 
     def film_can_go_to_planner(self, film_id):
         film = self.get_film_by_id(film_id)
-        return film.subsection.name != 'Industry'
+        return not film.subsection or film.subsection.name != 'Industry'
 
 
 if __name__ == "__main__":

--- a/FilmFestivalLoader/Shared/parse_tools.py
+++ b/FilmFestivalLoader/Shared/parse_tools.py
@@ -167,7 +167,7 @@ class BaseHtmlPageParser(HTMLParser):
     def bar(self):
         return f'{40 * "-"} '
 
-    def print_debug(self, str1, str2):
+    def print_debug(self, str1, str2=''):
         if self.debugging:
             self.debug_recorder.add(f'{self.debug_prefix}  {str1} {str2}')
 

--- a/FilmFestivalLoader/Shared/planner_interface.py
+++ b/FilmFestivalLoader/Shared/planner_interface.py
@@ -490,14 +490,14 @@ class FestivalData:
             return films[0]
         return None
 
-    def get_section(self, name):
+    def get_section(self, name, color=None):
         if name is None:
             return None
         try:
             section = self.section_by_name[name]
         except KeyError:
             self.curr_section_id += 1
-            section = Section(self.curr_section_id, name)
+            section = Section(self.curr_section_id, name, color=color)
             self.section_by_name[name] = section
             self.section_by_id[section.section_id] = section
         return section

--- a/FilmFestivalLoader/Tests/test_planner_interface.py
+++ b/FilmFestivalLoader/Tests/test_planner_interface.py
@@ -1,7 +1,7 @@
 import tempfile
 import unittest
 
-from Shared.planner_interface import FestivalData, Section, Screen
+from Shared.planner_interface import FestivalData, Section
 
 
 class SectionsTestCase(unittest.TestCase):
@@ -47,33 +47,6 @@ class SectionsTestCase(unittest.TestCase):
 
         # Assert.
         self.assertEqual(len(data.section_by_name), 2)
-
-
-class ScreensTestCase(unittest.TestCase):
-    def setUp(self):
-        self.temp_dir = tempfile.TemporaryDirectory()
-        self.festival_data = FestivalData(self.temp_dir.name)
-
-    def tearDown(self):
-        self.temp_dir.cleanup()
-
-    def test_screens_can_be_read(self):
-        # Arrange.
-        data = self.festival_data
-        city = 'Amsterdam'
-        theater_name = 'Kriterion'
-        screen_1 = data.get_screen(city, 'Kriterion Grote Zaal', theater_name)
-        screen_2 = data.get_screen(city, 'Kriterion Kleine Zaal', theater_name)
-        screen_1.abbr = 'krgr'
-        screen_2.abbr = 'krkl'
-        data.write_new_screens()
-
-        # Act.
-        data.read_screens()
-
-        # Assert.
-        self.assertEqual(len(data.screen_by_location), 2)
-        self.assertEqual(len(data.theater_by_location), 1)
 
 
 if __name__ == '__main__':

--- a/PresentScreenings/AppDelegate.cs
+++ b/PresentScreenings/AppDelegate.cs
@@ -72,7 +72,7 @@ namespace PresentScreenings.TableView
             Config = GetConfiguration();
 
             // Preferences.
-            Festival = "MTMF";
+            Festival = "Imagine";
             FestivalYear = "2023";
             VisitPhysical = true;
 
@@ -83,8 +83,9 @@ namespace PresentScreenings.TableView
             FilmRatingDialogController.OnlyFilmsWithScreenings = false;
             DaySchemaScreeningControl.UseCoreGraphics = false;
 
-            // Make sure the documents directory exists.
+            // Make sure the documents directories exist.
             _ = Directory.CreateDirectory(DocumentsFolder);
+            _ = Directory.CreateDirectory(CommonDataFolder);
 
             // Set load/unload file names.
             AvailabilitiesFile = Path.Combine(DocumentsFolder, "availabilities.csv");

--- a/PresentScreenings/Entities/Screen.cs
+++ b/PresentScreenings/Entities/Screen.cs
@@ -19,6 +19,7 @@ namespace PresentScreenings.TableView
             Location
         }
         private static Dictionary<ScreenType, ScreenTypeSortCode> sortCodeByType;
+        public static Dictionary<string, string> screenTypeByAddressType;
         #endregion
 
         #region Public Members
@@ -48,6 +49,11 @@ namespace PresentScreenings.TableView
             sortCodeByType.Add(ScreenType.OnLine, ScreenTypeSortCode.OnLine);
             sortCodeByType.Add(ScreenType.OnDemand, ScreenTypeSortCode.OnDemand);
             sortCodeByType.Add(ScreenType.Location, ScreenTypeSortCode.Location);
+
+            screenTypeByAddressType = new Dictionary<string, string> { };
+            screenTypeByAddressType["1"] = "2";
+            screenTypeByAddressType["2"] = "1";
+            screenTypeByAddressType["3"] = "0";
         }
 
         // Empty constructor to facilitate ListStreamer method calls.
@@ -62,9 +68,7 @@ namespace PresentScreenings.TableView
             string theaterIdString = fields[1];
             ParseName = fields[2];
             string screenAbbreviation = fields[3];
-
-            // TODO: Workaround should be fixed.
-            string screenType = (int.Parse(fields[4]) - 1).ToString();
+            string addresType = fields[4];
 
             // Assign properties that need calculating.
             ScreenId = int.Parse(screenIdString);
@@ -72,6 +76,7 @@ namespace PresentScreenings.TableView
             Theater = (from Theater t in ScreeningsPlan.Theaters where t.TheaterId == theaterId select t).First();
             City = Theater.City;
             Abbreviation = Theater.Abbreviation + screenAbbreviation;
+            string screenType = screenTypeByAddressType[addresType];
             Type = (ScreenType)Enum.Parse(typeof(ScreenType), screenType);
         }
 

--- a/PresentScreenings/Table Classes/ScreeningsTableDelegate.cs
+++ b/PresentScreenings/Table Classes/ScreeningsTableDelegate.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using AppKit;
 using Foundation;
 
@@ -20,6 +21,7 @@ namespace PresentScreenings.TableView
         ScreeningsTableDataSource _dataSource;
         ScreeningsView _screeningsView;
         ViewController _controller;
+        Dictionary<Theater.PriorityValue, NSColor> _colorByPriority;
         #endregion
 
         #region Constructors
@@ -28,6 +30,10 @@ namespace PresentScreenings.TableView
             _dataSource = datasource;
             _screeningsView = view;
             _controller = controller;
+            _colorByPriority = new Dictionary<Theater.PriorityValue, NSColor> { };
+            _colorByPriority.Add(Theater.PriorityValue.High, NSColor.SystemRed);
+            _colorByPriority.Add(Theater.PriorityValue.Low, NSColor.SystemBlue);
+            _colorByPriority.Add(Theater.PriorityValue.NoGo, NSColor.SystemGray);
         }
         #endregion
 
@@ -56,6 +62,8 @@ namespace PresentScreenings.TableView
                     NSTextField label = (NSTextField)cellview;
                     PopulateScreens(ref label);
                     label.StringValue = screen.ToString();
+                    label.TextColor = _colorByPriority[screen.Theater.Priority];
+                    label.ToolTip = $"Theater priority {screen.Theater.Priority}";
                     return label;
                 case "Screenings":
                     NSClipView clipview = (NSClipView)cellview;

--- a/PresentScreenings/Table Classes/ScreeningsTableDelegate.cs
+++ b/PresentScreenings/Table Classes/ScreeningsTableDelegate.cs
@@ -63,7 +63,7 @@ namespace PresentScreenings.TableView
                     PopulateScreens(ref label);
                     label.StringValue = screen.ToString();
                     label.TextColor = _colorByPriority[screen.Theater.Priority];
-                    label.ToolTip = $"Theater priority {screen.Theater.Priority}";
+                    label.ToolTip = $"{screen.ParseName}, theater priority {screen.Theater.Priority}";
                     return label;
                 case "Screenings":
                     NSClipView clipview = (NSClipView)cellview;

--- a/Tools/compare_planner_data.sh
+++ b/Tools/compare_planner_data.sh
@@ -5,10 +5,8 @@ declare -r files="
     filmids.txt
     films.csv
     screenings.csv
-    screens.csv
     sections.csv
     subsections.csv
-    theaters.csv
     filminfo.xml
 "
 declare -r film_file=films.csv


### PR DESCRIPTION
Support Imagine 2023

FilmFestivalLoader/Imagine/parse_imagine_html.py:
  Set actual festival edition.
Improve debug switch.
Derive theater from screen parse name.
Get Q&A attribute.
Adapt getting subsections.
Support section color.

FilmFestivalLoader/Shared/parse_tools.py:
  Make second parameter of print_debug() optional.

FilmFestivalLoader/Shared/planner_interface.py:
  Support section color.

PresentScreenings/AppDelegate.cs:
  Set actual festival edition.
Support common data directory.

PresentScreenings/Table Classes/ScreeningsTableDelegate.cs:
  Apply theater priority color.

Tools/compare_planner_data.sh:
  Support common data directory.

PresentScreenings/Entities/Screen.cs:
  Map Loader screen address type to Planner screen type.