### PR TITLE
Read screenings of IFFR 2024

### DIFF
--- a/FestivalPlanner/templates/films/films.html
+++ b/FestivalPlanner/templates/films/films.html
@@ -9,6 +9,8 @@
     </span>
     <span class="right-half">
         <a href="{% url 'loader:save_ratings' festival.id %}">Dump ratings</a>
+        <br>
+        <a href="{% url 'loader:ratings' %}">Load films and ratings</a>
     </span>
     {% if log %}
         <h3 style="color:{{ festival_color }}; margin-bottom: 2px">{{ log.action }} results</h3>

--- a/FestivalPlanner/templates/films/index.html
+++ b/FestivalPlanner/templates/films/index.html
@@ -30,7 +30,7 @@
     <br>
     <a href="{% url 'loader:sections' %}">Load sections</a>
     <br>
-    <a href="{% url 'loader:ratings' %}">Load ratings</a>
+    <a href="{% url 'loader:ratings' %}">Load films and ratings</a>
     <br><br>
     <a href="{% url 'authentication:set_test_cookie' %}">Test cookies</a>
     <br>

--- a/FilmFestivalLoader/IFFR/parse_iffr_html.py
+++ b/FilmFestivalLoader/IFFR/parse_iffr_html.py
@@ -258,8 +258,8 @@ class AzPageParser(HtmlPageParser):
                 error_collector.add(f'Unexpected category "{self.film.medium_category}"', error_msg)
             self.film.duration = self.duration
             self.film.sortstring = self.sorted_title
-            self.increase_fieature_short_counter(self.film)
-            self.increase_film_category_counter()
+            self.increase_per_duration_class_counter(self.film)
+            self.increase_per_film_category_counter()
             self.film_id_by_title[self.film.title] = self.film.filmid
             print(f'Adding FILM: {self.title} ({self.film.duration_str()}) {self.film.medium_category}')
             self.festival_data.films.append(self.film)
@@ -271,11 +271,11 @@ class AzPageParser(HtmlPageParser):
             film_info = FilmInfo(self.film.filmid, self.description, self.article)
             self.festival_data.filminfos.append(film_info)
 
-    def increase_fieature_short_counter(self, film):
+    def increase_per_duration_class_counter(self, film):
         key = 'feature films' if film.duration > self.max_short_duration else 'shorts'
         counter.increase(key)
 
-    def increase_film_category_counter(self):
+    def increase_per_film_category_counter(self):
         counter.increase(self.film.medium_category)
 
     def handle_starttag(self, tag, attrs):
@@ -517,6 +517,7 @@ class FilmInfoPageParser(ScreeningParser):
         self.film_info.article = self.article
 
     def set_combination(self):
+        self.print_debug('Updating combination program', f'{self.film}')
         self.film_info.screened_films = []
         for screened_film_slug in self.screened_film_slugs:
             if self.event_is_combi:
@@ -582,7 +583,6 @@ class FilmInfoPageParser(ScreeningParser):
                     self.screened_film_slugs.append(screened_film_slug)
                     self.state_stack.change(self.FilmInfoParseState.IN_SCREENED_FILM_LINK)
             elif tag == 'section':
-                self.print_debug('Updating combination program', f'{self.film}')
                 if has_category(self.film, Film.category_combinations) or self.event_is_combi:
                     self.set_combination()
                 self.state_stack.change(self.FilmInfoParseState.DONE)

--- a/FilmFestivalLoader/Shared/web_tools.py
+++ b/FilmFestivalLoader/Shared/web_tools.py
@@ -10,7 +10,6 @@ import json
 import os
 from enum import Enum, auto
 from json import JSONDecodeError
-from time import sleep
 from urllib.error import HTTPError
 from urllib.parse import quote, urlparse, urlunparse
 from urllib.request import urlopen, Request

--- a/PresentScreenings/AppDelegate.cs
+++ b/PresentScreenings/AppDelegate.cs
@@ -72,8 +72,8 @@ namespace PresentScreenings.TableView
             Config = GetConfiguration();
 
             // Preferences.
-            Festival = "IDFA";
-            FestivalYear = "2023";
+            Festival = "IFFR";
+            FestivalYear = "2024";
             VisitPhysical = true;
 
             MaxShortMinutes = int.Parse(Config.Constants["MaxShortMinutes"]);


### PR DESCRIPTION
* films.html: Add shortcut to the film loading page.

* index.html: Improve label of links to film loading page.

* parse_iffr_html.py: Support IFFR 2024. Allow separate "allways download" parameter for different medium types.
Improve section colors.
Add more counters.
Fix duplicate screenings caused by inconsequent festival pages. Leave (unreachable) code to circumvent gupta's.

* web_tools.py: Remove unused import.

* AppDelegate.cs: Switch to IFFR 2024.