### PR TITLE
Fix global cache

### DIFF
--- a/FestivalPlanner/templates/films/films.html
+++ b/FestivalPlanner/templates/films/films.html
@@ -72,14 +72,14 @@
                 <th class="sticky-t-head">
                     Duration
                     <br>
-                    <a href="/films/films?filter=shorts">{{ display_shorts_action }}</a>
+                    <a href="/films/films?shorts={{ display_shorts_query }}">{{ display_shorts_action }}</a>
                 </th>
                 <th class="sticky-t-head" style="vertical-align: text-top;">Subsection<br></th>
                 {% for fan_header in fan_headers %}
                     <th class="sticky-t-head">
                         {{ fan_header.fan }}
                         <br>
-                        <a href="/films/films?filter_{{ fan_header.fan }}=rated">{{ fan_header.action }}</a>
+                        <a href="/films/films?rated_{{ fan_header.fan }}={{ fan_header.query }}">{{ fan_header.action }}</a>
                     </th>
                 {% endfor %}
             </tr>

--- a/FilmFestivalLoader/Shared/planner_interface.py
+++ b/FilmFestivalLoader/Shared/planner_interface.py
@@ -794,7 +794,7 @@ class FestivalData:
         data = [i for i in self.filminfos if self.film_can_go_to_planner(i.filmid)]
         # with open(self.filminfo_yaml_file, 'w') as stream:
         #     yaml.dump(data, stream, indent=4)
-        rows = [[i.filmid, i.description] for i in data]
+        rows = sorted([[i.filmid, i.description] for i in data], key=lambda row: row[0])
         with open(self.filminfo_yaml_file, 'w') as csvfile:
             csv_writer = csv.writer(csvfile, self.dialect)
             csv_writer.writerows(rows)


### PR DESCRIPTION
* views.py: Fix global filter-cache, separate cache per session. Stabilize filtering while refreshing page.
Allow absence of descriptions file.

* films.html: Stabilize filtering while refreshing page.

* parse_iffr_html.py: Filter out screenings of main films when screenings of derived events exist.

* planner_interface.py: Sort descriptions to ease comparison of earlier version.