### PR TITLE
Support all necessary screenig data

### DIFF
--- a/FestivalPlanner/loader/forms/loader_forms.py
+++ b/FestivalPlanner/loader/forms/loader_forms.py
@@ -299,6 +299,8 @@ class SimpleLoader(BaseLoader):
             disappeared_object_set = existing_object_set - updated_object_set
             disappeared_pk_list = [obj.pk for obj in disappeared_object_set]
             disappeared_objects = existing_objects.filter(pk__in=disappeared_pk_list)
+            for obj in disappeared_objects:
+                self.add_log(f'{obj=} will be deleted')
 
             # Delete disappeared objects from the database.
             self.delete_objects(disappeared_objects)

--- a/FestivalPlanner/templates/loader/new_screens.html
+++ b/FestivalPlanner/templates/loader/new_screens.html
@@ -6,7 +6,12 @@
 {% block content %}
     {% load static %}
     {% if log %}
-        <h3 style="color:{{ festival_color }}; margin-bottom: 2px">{{ log.action }} results</h3>
+        <span class="left-half">
+            <h3 style="color:{{ festival_color }}; margin-bottom: 2px">{{ log.action }} results</h3>
+        </span>
+        <span class="right-half">
+            <a href="{% url 'theaters:theaters' %}">Theater index</a>
+        </span>
         {% for result in log.results %}
             <p class="log">{{ result }}</p>
         {% endfor %}

--- a/FestivalPlanner/templates/theaters/details.html
+++ b/FestivalPlanner/templates/theaters/details.html
@@ -10,6 +10,8 @@
         </span>
         <span class="right-half">
             <a href="{% url 'theaters:theaters' %}">Back to theater index</a>
+            <br>
+            <a href="{% url 'loader:new_screens' %}">New theater data</a>
         </span>
         {% if form_errors %}
             <h2 class="error">Form Error</h2>

--- a/FilmFestivalLoader/Shared/planner_interface.py
+++ b/FilmFestivalLoader/Shared/planner_interface.py
@@ -333,7 +333,7 @@ class Screen:
         self.new = new
 
     def __str__(self):
-        return self.abbr
+        return f'{self.theater.abbr}{self.abbr}'
 
     def __repr__(self):
         text = ';'.join([

--- a/PresentScreenings/AppDelegate.cs
+++ b/PresentScreenings/AppDelegate.cs
@@ -79,7 +79,8 @@ namespace PresentScreenings.TableView
             MaxShortMinutes = int.Parse(Config.Constants["MaxShortMinutes"]);
             MaxShortDuration = new TimeSpan(0, MaxShortMinutes, 0);
             PauseBetweenOnDemandScreenings = new TimeSpan(0, 30, 0);
-            Screening.TravelTime = new TimeSpan(0, 30, 0);
+            Screening.WalkTimeSameTheater = new TimeSpan(0, 15, 0);
+            Screening.TravelTimeOtherTheater = new TimeSpan(0, 40, 0);
             FilmRatingDialogController.OnlyFilmsWithScreenings = false;
             DaySchemaScreeningControl.UseCoreGraphics = false;
 

--- a/PresentScreenings/Entities/Screening.cs
+++ b/PresentScreenings/Entities/Screening.cs
@@ -78,7 +78,8 @@ namespace PresentScreenings.TableView
 
         #region Static Properties
         public static Action<Screening> GoToScreening { get; set; }
-        public static TimeSpan TravelTime { get; set; }
+        public static TimeSpan WalkTimeSameTheater { get; set; }
+        public static TimeSpan TravelTimeOtherTheater { get; set; }
         public static bool InOutliningOverlaps { get; set; } = false;
         public static Dictionary<string, int> IndexByName { get; }
         #endregion
@@ -290,9 +291,16 @@ namespace PresentScreenings.TableView
 
         public bool Overlaps(Screening otherScreening, bool useTravelTime = false)
         {
-            var travelTime = useTravelTime ? TravelTime : TimeSpan.Zero;
+            var travelTime = useTravelTime ? GetTravelTime(otherScreening) : TimeSpan.Zero;
             return otherScreening.StartTime <= EndTime + travelTime
                 && otherScreening.EndTime >= StartTime - travelTime;
+        }
+
+        public TimeSpan GetTravelTime(Screening otherScreening)
+        {
+            var sameTheater = Screen.Theater.TheaterId == otherScreening.Screen.Theater.TheaterId;
+            var travelTime = sameTheater ? WalkTimeSameTheater : TravelTimeOtherTheater;
+            return travelTime;
         }
         #endregion
 


### PR DESCRIPTION
* loader_forms.py: Save (kind of) deleted object in the log.

* details.html, new_screens.html: Add often-used links.

* parse_iffr_html.py: Add new (i.e. not as such marked by the festival) combination programs from screening pages.
Update theaters and screens in Rotterdam.
Remove all code used to fabricate screenings, combination programs etc.
Read sold out propterty of screenings (not used yet).

* planner_interface.py: Improve theater string representation.

* AppDelegate.cs, Screening.cs: Distinguish travel time between theaters from travel time within theaters.