### PR TITLE
Improve tests, half-way commit

### DIFF
--- a/FestivalPlanner/films/views.py
+++ b/FestivalPlanner/films/views.py
@@ -315,12 +315,15 @@ class ResultsView(DetailView):
     @staticmethod
     def get_description(film):
         film_info_file = film.festival.filminfo_file
-        # with open(film_info_file, 'r') as stream:
-        #     info = yaml.safe_load(stream)
-        # description = info['description']
-        with open(film_info_file, 'r', newline='') as csvfile:
-            object_reader = csv.reader(csvfile, delimiter=';', quotechar='"')
-            descriptions = [row[1] for row in object_reader if film.film_id == int(row[0])]
+        try:
+            # with open(film_info_file, 'r') as stream:
+            #     info = yaml.safe_load(stream)
+            # description = info['description']
+            with open(film_info_file, 'r', newline='') as csvfile:
+                object_reader = csv.reader(csvfile, delimiter=';', quotechar='"')
+                descriptions = [row[1] for row in object_reader if film.film_id == int(row[0])]
+        except FileNotFoundError as e:
+            descriptions = []
         description = descriptions[0] if descriptions else '-'
         return description
 

--- a/FilmFestivalLoader/IFFR/parse_iffr_html.py
+++ b/FilmFestivalLoader/IFFR/parse_iffr_html.py
@@ -55,6 +55,13 @@ def main():
     Film.category_by_string['OtherProgram'] = Film.category_events
 
     # Set-up counters.
+    setup_counters()
+
+    # Try parsing the websites.
+    try_parse_festival_sites(parse_iffr_sites, festival_data, error_collector, debug_recorder, festival, counter)
+
+
+def setup_counters():
     counter.start('no description')
     counter.start('Film')
     counter.start('CombinedProgram')
@@ -69,9 +76,6 @@ def main():
     for screened_film_type in ScreenedFilmType:
         counter.start(screened_film_type.name)
     counter.start('wrong_title')
-
-    # Try parsing the websites.
-    try_parse_festival_sites(parse_iffr_sites, festival_data, error_collector, debug_recorder, festival, counter)
 
 
 def parse_iffr_sites(festival_data):

--- a/FilmFestivalLoader/Shared/planner_interface.py
+++ b/FilmFestivalLoader/Shared/planner_interface.py
@@ -101,24 +101,28 @@ class Film:
         'combinations': category_combinations,
         'events': category_events,
     }
+    minutes_mark = '′'
     mapper = UnicodeMapper()
     articles_by_language = {}
     language_by_title = {}
     re_alpha = re.compile(r'^[a-zA-Z]')
 
-    def __init__(self, seqnr, filmid, title, url):
+    def __init__(self, seqnr, filmid, title, url, duration=None, medium_category=None):
         self.seqnr = seqnr
         self.filmid = filmid
         self.title = title
         self.url = url
         self.title_language = self.language()
         self.subsection = None
-        self.duration = None
-        self.medium_category = None
+        self.duration = duration
+        self.medium_category = medium_category
         self.sortstring = self.lower(self.strip_article())
 
     def __str__(self):
-        return ", ".join([str(self.filmid), self.title, self.duration_str(), self.medium_category])
+        return ", ".join([str(self.filmid),
+                          self.title,
+                          self.duration_str() if self.duration else '',
+                          self.medium_category])
 
     def __lt__(self, other):
         return self.sortstring < other.sortstring
@@ -146,7 +150,7 @@ class Film:
             self.title,
             self.title_language,
             str(self.subsection.subsection_id) if self.subsection is not None else '',
-            self.duration_str(),
+            self.duration_str() if self.duration else '0' + self.minutes_mark,
             self.category_by_string[self.medium_category],
             self.url
         ]
@@ -164,7 +168,7 @@ class Film:
 
     def duration_str(self):
         minutes = Film.duration_to_minutes(self.duration)
-        return str(minutes) + "′"
+        return str(minutes) + self.minutes_mark
 
     def language(self):
         try:
@@ -496,15 +500,6 @@ class FestivalData:
     def film_key(self, title, url):
         return title
 
-    def create_film(self, title, url):
-        film_id = self.new_film_id(self.film_key(title, url))
-        if film_id not in [f.filmid for f in self.films]:
-            self.film_seqnr += 1
-            self.title_by_film_id[film_id] = title
-            self.film_id_by_url[url] = film_id
-            return Film(self.film_seqnr, film_id, title, url)
-        return None
-
     def new_film_id(self, key):
         try:
             film_id = self.film_id_by_key[key]
@@ -513,6 +508,21 @@ class FestivalData:
             film_id = self.curr_film_id
             self.film_id_by_key[key] = film_id
         return film_id
+
+    def create_film(self, title, url, duration=None, medium_category=None):
+        film_id = self.new_film_id(self.film_key(title, url))
+        if film_id not in [f.filmid for f in self.films]:
+            self.film_seqnr += 1
+            self.title_by_film_id[film_id] = title
+            self.film_id_by_url[url] = film_id
+            return Film(self.film_seqnr, film_id, title, url, duration=duration, medium_category=medium_category)
+        return None
+
+    def add_film(self, title, url, duration=None, medium_category=None):
+        film = self.create_film(title, url, duration=duration, medium_category=medium_category)
+        if film:
+            self.films.append(film)
+        return film
 
     def get_film_by_key(self, title, url):
         key = self.film_key(title, url)
@@ -642,7 +652,6 @@ class FestivalData:
             self.curr_film_id = max(self.film_id_by_key.values())
         except ValueError:
             self.curr_film_id = 0
-        print(f"Done reading {len(self.film_id_by_url)} records from {self.filmids_file}.")
 
     def read_sections(self):
         try:

--- a/FilmFestivalLoader/Tests/AuxiliaryClasses/test_film.py
+++ b/FilmFestivalLoader/Tests/AuxiliaryClasses/test_film.py
@@ -12,6 +12,3 @@ class TestFilm(Film):
         self.url = url
         self.duration = datetime.timedelta(minutes=minutes)
         self.description = description
-
-    def film_info(self, festival_data):
-        return self.film_info(festival_data)

--- a/FilmFestivalLoader/Tests/test_planner_interface.py
+++ b/FilmFestivalLoader/Tests/test_planner_interface.py
@@ -1,16 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import tempfile
 import unittest
+from datetime import timedelta
+from unittest import skip
 
-from Shared.planner_interface import FestivalData, Section
+from Shared.planner_interface import FestivalData, Section, Film
 
 
-class SectionsTestCase(unittest.TestCase):
+class FestivalDataBaseTestCase(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
         self.festival_data = FestivalData(self.temp_dir.name)
 
     def tearDown(self):
         self.temp_dir.cleanup()
+
+
+class SectionsTestCase(FestivalDataBaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
 
     def test_sections_do_not_need_to_be_present(self):
         # Arrange.
@@ -47,6 +60,96 @@ class SectionsTestCase(unittest.TestCase):
 
         # Assert.
         self.assertEqual(len(data.section_by_name), 2)
+
+
+class TestDrivenDevAddFilmTestCase(FestivalDataBaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test_add_new_film(self):
+        # Arrange.
+        self.assertEqual(len(self.festival_data.films), 0)
+        film_args = [
+            'Amphetamine',
+            'https://iffr.com/nl/iffr/2024/films/amphetamine',
+        ]
+        film_kwargs = {
+            'duration': timedelta(minutes=97),
+        }
+
+        # Act.
+        self.festival_data.add_film(*film_args, **film_kwargs)
+
+        # Assert.
+        films = self.festival_data.films
+        self.assertEqual(len(films), 1)
+        self.assertIsInstance(films[0], Film)
+
+    def test_add_existing_title_film(self):
+        # Arrange.
+        film_args = [
+            'Amphetamine',
+            'https://iffr.com/nl/iffr/2024/films/amphetamine',
+        ]
+        film_kwargs_1 = {
+            'duration': timedelta(minutes=11),
+        }
+        film_kwargs_2 = {
+            'duration': timedelta(minutes=204),
+        }
+
+        # Act.
+        film_1 = self.festival_data.add_film(*film_args, **film_kwargs_1)
+        film_2 = self.festival_data.add_film(*film_args, **film_kwargs_2)
+
+        # Assert.
+        films = self.festival_data.films
+        self.assertEqual(len(films), 1)
+        self.assertEqual(films[0].duration, film_1.duration)
+        self.assertEqual(films[0], film_1)
+        self.assertIsNone(film_2)
+
+    def test_add_existing_url_film(self):
+        # Arrange.
+        film_args_1 = [
+            'Love and Underworld',
+            'https://iffr.com/nl/iffr/2024/films/ammore-e-malavita',
+        ]
+        film_args_2 = {
+            'Ammore e malavita',
+            'https://iffr.com/nl/iffr/2024/films/ammore-e-malavita',
+        }
+
+        # Act.
+        film_1 = self.festival_data.add_film(*film_args_1)
+        film_2 = self.festival_data.add_film(*film_args_2)
+
+        # Assert.
+        films = self.festival_data.films
+        self.assertEqual(len(films), 1, 'Second film, with same URL, should be refused')
+        self.assertEqual(films[0], film_1)
+        self.assertIsNone(film_2)
+
+    @skip
+    def test_add_new_title_existing_url(self):
+        # Arrange.
+        pass
+
+        # Act.
+
+        # Assert.
+
+    @skip
+    def test_add_new_url_existing_title(self):
+        # Arrange.
+        pass
+
+        # Act.
+
+        # Assert.
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* views.py: Stop code from crashing when no film info file is available.
Commented out code can be kept as an ugly remonder to start using YAML.

* parse_iffr_html.py: Get the list of counters out of the main program.

* planner_interface.py: Add optional duration and medium category to Film initialization as a preparation of making these fields mandatory. Protect string functions against the absence of these fields. Add a generic add_film() method, to be developed test driven.

* test_film.py: Remove unused function.

* test_iffr_parser.py: Test without dependance on the AZ-parser. Use a base class to avoid repeating the same set-up and tear-down methods.

* test_planner_interface.py: Use a base class to avoid repeating the same set-up and tear-down methods.
New tests to develop generic method add_film() test driven (in progress).