### PR TITLE
Support Imagine 2024

### DIFF
--- a/FestivalPlanner/availabilities/views.py
+++ b/FestivalPlanner/availabilities/views.py
@@ -18,7 +18,7 @@ DAY_BREAK_TIME = datetime.time(hour=6)
 DAY_START_TIME = datetime.time(hour=8)
 TIME_CHOICES = [
     DAY_START_TIME.strftime('%H:%M'),
-    '10:00', '12:00', '13:00', '15:00', '18:00', '20:00', '23:00', '00:30',
+    '10:00', '11:00', '12:00', '13:00', '15:00', '18:00', '20:00', '23:00', '00:30',
     DAY_BREAK_TIME.strftime('%H:%M')
 ]
 START_TIME_CHOICES = TIME_CHOICES[:-1]

--- a/FestivalPlanner/festivals/models.py
+++ b/FestivalPlanner/festivals/models.py
@@ -100,7 +100,10 @@ class Festival(models.Model):
     def films_file(self):
         return os.path.join(self.planner_data_dir(), 'films.csv')
 
-    def filminfo_file(self):
+    def filminfo_csv_file(self):
+        return os.path.join(self.planner_data_dir(), 'filminfo.csv')
+
+    def filminfo_yaml_file(self):
         return os.path.join(self.planner_data_dir(), 'filminfo.yml')
 
     def ratings_file(self):

--- a/FestivalPlanner/festivals/static/festivals/project_style.css
+++ b/FestivalPlanner/festivals/static/festivals/project_style.css
@@ -330,7 +330,7 @@ span.up {
 .dropdown {
     position: relative;
     display: block;
-    background-color: var(--inputBackground);
+    background: var(--inputBackground);
     text-align: center;
     margin: auto;
     width: auto;
@@ -344,7 +344,7 @@ span.up {
 .drop-button {
     position: relative;
     color: var(--modestStandoutColor);
-    background-color: transparent;
+    background: transparent;
     margin: auto;
     padding: 2px;
     font-size: 16px;
@@ -393,12 +393,11 @@ span.up {
 .modest-dropdown {
     position: relative;
     display: table-cell;
-    background-color: var(--modestBackground);
+    background: var(--modestBackground);
     text-align: left;
     margin: auto;
     width: auto;
     height: auto;
-
 }
 .modest-dropdown:hover {
     background-color: var(--hoverBackground);

--- a/FestivalPlanner/films/models.py
+++ b/FestivalPlanner/films/models.py
@@ -7,6 +7,7 @@ from sections.models import Subsection
 MINUTES_STR = "'"
 UNRATED_STR = '-'
 FANS_IN_RATINGS_TABLE = ['Maarten', 'Adrienne']
+MIN_ALARM_RATING_DIFF = 3
 
 
 class Film(models.Model):
@@ -39,15 +40,6 @@ class Film(models.Model):
 
     def duration_str(self):
         return ':'.join(f'{self.duration}'.split(':')[:2])
-
-    def film_rating(self):
-        """ The highest rating represents all ratings of a film"""
-        film_rating = FilmFanFilmRating.film_ratings.filter(film=self).order_by('-rating').first()
-        if film_rating:
-            rating = film_rating.rating
-        else:
-            rating = FilmFanFilmRating.Rating.UNRATED
-        return rating
 
 
 class FilmFanFilmRating(models.Model):

--- a/FestivalPlanner/films/views.py
+++ b/FestivalPlanner/films/views.py
@@ -647,7 +647,7 @@ class FilmDetailView(LoginRequiredMixin, DetailView):
         else:
             try:
                 description = descriptions[0].strip() or None
-            except IndexError as e:
+            except IndexError:
                 description = None
         return description
 

--- a/FestivalPlanner/screenings/models.py
+++ b/FestivalPlanner/screenings/models.py
@@ -73,6 +73,8 @@ class Screening(models.Model):
         ScreeningStatus.NO_TRAVEL_TIME: color_pair('white', 'blue'),
         ScreeningStatus.NEEDS_TICKETS: color_pair('white', 'blue'),
     }
+    interesting_rating_color_attends_film_background = 'blue'
+    uninteresting_rating_color = 'grey'
 
     # Define the fields.
     film = models.ForeignKey(Film, on_delete=models.CASCADE)
@@ -147,11 +149,11 @@ class Screening(models.Model):
             color = regular_color
         elif rating_is_interesting:
             if attends_film:
-                color = 'blue'
+                color = Screening.interesting_rating_color_attends_film_background
             else:
                 color = regular_color
         else:
-            color = 'grey'
+            color = Screening.uninteresting_rating_color
         return film_rating_str, color
 
 

--- a/FestivalPlanner/templates/availabilities/list.html
+++ b/FestivalPlanner/templates/availabilities/list.html
@@ -4,15 +4,16 @@
 {% block header %}{{ title }}{% endblock %}
 
 {% block content %}
-    <h2 class="row col-left-h2">Availabilities overview</h2>
-    <span class="row">
-        <span class="col-right">
-            <a href="{% url 'screenings:day_schema' %}">Day schema</a>
-            <br>
-            <a href="{% url 'films:films' %}">Ratings</a>
-        </span>
+<h2 class="row col-left-h2">Availabilities overview</h2>
+<span class="row">
+    <span class="col-right">
+        <a href="{% url 'screenings:day_schema' %}">Day schema</a>
+        <br>
+        <a href="{% url 'films:films' %}">Ratings</a>
     </span>
+</span>
 
+{% if user_is_admin %}
     <div class="no-select">
         <h3>Add an availability period</h3>
 
@@ -129,4 +130,8 @@
     {% endif %}
     </div>
     <br>
+{% else %}
+    <h2 class="error">Not allowed</h2>
+    <p>Only an admin fan can maintain availabilities.</p>
+{% endif %}
 {% endblock %}}

--- a/FestivalPlanner/templates/films/details.html
+++ b/FestivalPlanner/templates/films/details.html
@@ -29,6 +29,9 @@
         <li>Reviewer: {% if film.reviewer %} {{ film.reviewer }} {% else %} - {% endif %}</li>
         <li>Medium category: {{ film.medium_category }}</li>
         <li>Rating count: {{ film.filmfanfilmrating_set.count }}</li>
+        {% for item in metadata %}
+            <li>{{ item.key }}: {{ item.value }}</li>
+        {% endfor %}
     </ul>
     <br>
     <form method="post">

--- a/FestivalPlanner/templates/loader/ratings.html
+++ b/FestivalPlanner/templates/loader/ratings.html
@@ -5,7 +5,12 @@
 
 {% block content %}
     {% if user_is_admin %}
-        <h2>Pick a festival to load rating data from</h2>
+        <h2 class="row col-left-h2">Pick a festival to load rating data from</h2>
+        <div class="row">
+            <span class="col-right">
+                <a href="{% url 'films:films' %}">Film ratings</a>
+            </span>
+        </div>
         {% if unexpected_error %}
             <h2 class="error">Unexpected error</h2>
             <p>{{ unexpected_error }}</p>

--- a/FestivalPlanner/templates/screenings/day_schema.html
+++ b/FestivalPlanner/templates/screenings/day_schema.html
@@ -49,13 +49,15 @@
 <div>
     {% with props=selected_screening_props %}
     <h3>
-        Selected screening
+        <span class="label-8rem">
+            Selected:
+        </span>
         <span class="modest-dropdown inline-dropdown-addition">
-            <span class="active-text" style="color: {{ festival_color }}">
+            <span class="active-text" style="color: var(--modestStandoutColor);">
                 {{ props.selected_screening }}
             </span>
             <span class="modest-dropdown-content"
-                  style="min-width:42rem; margin-left: 12rem; background-color: black; cursor: default;">
+                  style="min-width:42rem; margin-left: 12rem; background: black; cursor: default;">
                 <table>
                     <tbody>
                     <tr>
@@ -87,6 +89,12 @@
                         <td>{% if props.q_and_a %} {{ props.q_and_a }} {% else %} - {% endif %}</td>
                     </tr>
                     <tr>
+                        <th>Film subsection</th>
+                        <td style="background: {{ props.subsection.section.color }}; color: var(--modestStandoutColor);">
+                            {% if props.subsection %} {{ props.subsection.name }} {% else %} - {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
                         <th>Film description</th>
                         <td>{% if props.description %} {{ props.description }} {% else %} - {% endif %}</td>
                     </tr>
@@ -106,7 +114,7 @@
 {% endif %}
 
 
-{% if screen_rows %}
+{% if screen_rows or availability_props %}
     <table class="day-schema-border">
         <thead>
         <tr class="sticky-t-head" >
@@ -154,7 +162,7 @@
                 {% for prop in row.screening_props %}
                     {% with info=prop.info_pair %}
                     <span class="day-schema-screening"
-                          style="background: {{ prop.pair.background }}; color: {{ prop.pair.color }}; left: {{ prop.left }}px; width: {{ prop.width }}px; border: 1px solid {{ prop.frame_color }};">
+                          style="background: {{ prop.pair.background }}; color: {{ prop.pair.color }}; left: {{ prop.left }}px; width: {{ prop.width }}px; border: 1px solid {{ prop.frame_color }}; border-right: 1px solid {{ prop.section_color }};">
                         <a style="color: {{ prop.pair.color }};" href="{% url 'screenings:details' prop.screening.id %}">
                             {{ prop.line_1 }}
                         </a>

--- a/FilmFestivalLoader/Imagine/parse_imagine_html.py
+++ b/FilmFestivalLoader/Imagine/parse_imagine_html.py
@@ -5,43 +5,66 @@ Created on Thu Mar 18 20:56:44 2021
 
 @author: maartenroos
 """
-
+import csv
 import datetime
+import os
 import re
 from enum import Enum, auto
 
-from Shared.application_tools import ErrorCollector, DebugRecorder, comment
+from Shared.application_tools import ErrorCollector, DebugRecorder, comment, Counter
 from Shared.parse_tools import FileKeeper, HtmlPageParser, try_parse_festival_sites
 from Shared.planner_interface import FilmInfo, FestivalData, Film, get_screen_from_parse_name
 from Shared.web_tools import UrlFile
 
-# Parameters.
-festival = 'Imagine'
-year = 2023
-festival_city = 'Amsterdam'
-ondemand_available_hours = None
+DOWNLOAD_WORKS = True       # Python html reader gets "certificate not found", used curl instead.
+FILE_BY_URL = {}
+ALWAYS_DOWNLOAD = False
+Q_AND_A_SCREENING_KEYS = []
+
+FESTIVAL = 'Imagine'
+FESTIVAL_YEAR = 2024
+FESTIVAL_CITY = 'Amsterdam'
 
 # Files.
-fileKeeper = FileKeeper(festival, year)
-az_file = fileKeeper.az_file()
-debug_file = fileKeeper.debug_file
+FILE_KEEPER = FileKeeper(FESTIVAL, FESTIVAL_YEAR)
+AZ_FILE = FILE_KEEPER.az_file()
+URL_MAP_FILE = os.path.join(FILE_KEEPER.webdata_dir, 'url_map.txt')
 
 # URL information.
-imagine_hostname = 'https://www.imaginefilmfestival.nl'
-az_url_path = f'/programma{year}'
+IMAGINE_HOSTNAME = 'https://www.imaginefilmfestival.nl'
+AZ_URL_PATH = f'/programma{FESTIVAL_YEAR}'
 
 # Application tools.
-error_collector = ErrorCollector()
-debug_recorder = DebugRecorder(debug_file)
+ERROR_COLLECTOR = ErrorCollector()
+DEBUG_RECORDER = DebugRecorder(FILE_KEEPER.debug_file)
+COUNTER = Counter()
 
 
 def main():
     # Initialize a festival data object.
     comment('Creating festival data object.')
-    festival_data = ImagineData(fileKeeper.plandata_dir)
+    festival_data = ImagineData(FILE_KEEPER.plandata_dir)
+
+    # Set up counters.
+    COUNTER.start('q&a screenings')
 
     # Try parsing the websites.
-    try_parse_festival_sites(parse_imagine_sites, festival_data, error_collector, debug_recorder)
+    try_parse_festival_sites(parse_imagine_sites, festival_data, ERROR_COLLECTOR, DEBUG_RECORDER, counter=COUNTER)
+
+    # Write a map file for curl if downloading doesn't work.
+    write_url_map_file()
+
+
+def write_url_map_file():
+    dialect = csv.unix_dialect
+    dialect.delimiter = ';'
+    dialect.quotechar = '"'
+    dialect.doublequote = True
+    dialect.quoting = csv.QUOTE_MINIMAL
+    rows = [[url, file] for url, file in FILE_BY_URL.items()]
+    with open(URL_MAP_FILE, 'w', newline='') as csvfile:
+        csv_writer = csv.writer(csvfile, dialect=dialect)
+        csv_writer.writerows(rows)
 
 
 def parse_imagine_sites(festival_data):
@@ -50,22 +73,21 @@ def parse_imagine_sites(festival_data):
 
 
 def get_films(festival_data):
-    az_url = imagine_hostname + az_url_path
-    url_file = UrlFile(az_url, az_file, error_collector, debug_recorder, byte_count=100)
-    az_html = url_file.get_text()
+    az_url = IMAGINE_HOSTNAME + AZ_URL_PATH
+    url_file = UrlFile(az_url, AZ_FILE, ERROR_COLLECTOR, DEBUG_RECORDER, byte_count=100)
+    az_html = url_file.get_text(always_download=ALWAYS_DOWNLOAD)
     if az_html is not None:
         AzPageParser(festival_data).feed(az_html)
 
 
-def get_details_of_all_films(festival_data):
-    for film in festival_data.films:
-        get_details_of_one_film(festival_data, film)
-
-
 def get_details_of_one_film(festival_data, film):
-    film_file = fileKeeper.film_webdata_file(film.film_id)
-    url_file = UrlFile(film.url, film_file, error_collector, debug_recorder, byte_count=256)
-    film_html = url_file.get_text(f'Downloading site of {film.title}: {film.url}')
+    film_file = FILE_KEEPER.film_webdata_file(film.film_id)
+    if not DOWNLOAD_WORKS:
+        FILE_BY_URL[film.url] = film_file
+        return
+    url_file = UrlFile(film.url, film_file, ERROR_COLLECTOR, DEBUG_RECORDER, byte_count=256)
+    comment_at_download = f'Downloading site of {film.title}: {film.url}'
+    film_html = url_file.get_text(comment_at_download=comment_at_download, always_download=ALWAYS_DOWNLOAD)
 
     if film_html is not None:
         print(f"Analysing html file {film.film_id} of {film.title} {film.url}")
@@ -85,10 +107,8 @@ class AzPageParser(HtmlPageParser):
         IN_LANGUAGE = auto()
         IN_DURATION = auto()
 
-    num_screen_re = re.compile(r'^(?P<theater>.*?) (?P<number>\d+)$')
-
     def __init__(self, festival_data):
-        HtmlPageParser.__init__(self, festival_data, debug_recorder, 'AZ', debugging=True)
+        HtmlPageParser.__init__(self, festival_data, DEBUG_RECORDER, 'AZ', debugging=True)
         self.sorting_from_site = False
         self.film = None
         self.url = None
@@ -112,11 +132,12 @@ class AzPageParser(HtmlPageParser):
     @staticmethod
     def init_categories():
         Film.category_by_string['Extra'] = Film.category_films
-        Film.category_by_string['Feature'] = Film.category_films
-        Film.category_by_string['Shorts'] = Film.category_combinations
-        Film.category_by_string['Special'] = Film.category_events
+        Film.category_by_string['feature'] = Film.category_films
+        Film.category_by_string['shorts'] = Film.category_combinations
+        Film.category_by_string['special'] = Film.category_events
         Film.category_by_string['Talk'] = Film.category_events
         Film.category_by_string['Workshop'] = Film.category_events
+        Film.category_by_string['vr/expanded'] = Film.category_events
 
     def init_screening_data(self):
         self.film = None
@@ -143,31 +164,8 @@ class AzPageParser(HtmlPageParser):
 
     def get_imagine_screen(self, data):
         screen_parse_name = data.strip()
-        return get_screen_from_parse_name(self.festival_data, screen_parse_name, self.split_location)
-
-    def split_location(self, location):
-        city_name = festival_city
-        theater_parse_name = location
-        default_screen_abbreviation = 'zaal'
-        num_match = self.num_screen_re.match(location)
-        if location.startswith('KINO'):
-            city_name = 'Rotterdam'
-        if location == 'SPUI 25':
-            theater_parse_name = location
-            screen_abbreviation = default_screen_abbreviation
-        elif location == 'OBA Oosterdok OBA Theater':
-            location_words = location.split()
-            theater_parse_name = ' '.join(location_words[:2])
-            screen_abbreviation = ' '.join(location_words[2:])
-        elif num_match:
-            theater_parse_name = num_match.group(1)
-            screen_abbreviation = num_match.group(2)
-        elif location.startswith('LAB111 '):
-            theater_parse_name = 'LAB111'
-            screen_abbreviation = location.split()[1]
-        else:
-            screen_abbreviation = default_screen_abbreviation
-        return city_name, theater_parse_name, screen_abbreviation
+        splitter = LocationSplitter.split_location
+        return get_screen_from_parse_name(self.festival_data, screen_parse_name, splitter)
 
     def get_title(self, data):
         qa_string = ' + Q&A'
@@ -186,7 +184,7 @@ class AzPageParser(HtmlPageParser):
         # Create a new film.
         self.film = self.festival_data.create_film(self.title, self.url)
         if self.film is None:
-            error_collector.add(f'Could not create film:', '{self.title} ({self.url})')
+            ERROR_COLLECTOR.add(f'Could not create film:', '{self.title} ({self.url})')
         else:
             # Fill details.
             self.film.duration = self.duration
@@ -213,13 +211,12 @@ class AzPageParser(HtmlPageParser):
         # Get the film.
         try:
             self.film = self.festival_data.get_film_by_key(self.title, self.url)
-        except KeyError:
-            self.add_film()
-        except ValueError:
+        except (KeyError, ValueError):
             self.add_film()
 
         # Calculate the screening's end time.
         duration = self.film.duration
+        self.start_dt = self.start_dt.replace(tzinfo=None)
         self.end_dt = self.start_dt + duration
 
         # Add screening to the list.
@@ -234,31 +231,36 @@ class AzPageParser(HtmlPageParser):
         # Initialize the next round of parsing.
         self.init_screening_data()
 
+    def feed(self, data):
+        super().feed(data)
+        comment('Assigning Q&A property to the relevant screenings.')
+        QaScreeningKey.update_q_and_a_screenings(self.festival_data)
+
     def handle_starttag(self, tag, attrs):
         HtmlPageParser.handle_starttag(self, tag, attrs)
 
-        if self.stateStack.state_is(self.AzParseState.IDLE) and tag == 'ul' and len(attrs) > 0:
+        if self.stateStack.state_is(self.AzParseState.IDLE) and tag == 'ul' and attrs:
             if attrs[0][1] == 'screenings imagine-rows filterable':
                 self.stateStack.change(self.AzParseState.IN_LIST)
         elif self.stateStack.state_is(self.AzParseState.IN_LIST) and tag == 'li' and len(attrs) > 3:
             if attrs[0][1] == 'screening item':
-                self.url = attrs[1][1]
+                self.url = attrs[2][1]
                 self.sort_title = attrs[3][1]
                 self.stateStack.push(self.AzParseState.IN_SCREENING)
-        elif self.stateStack.state_is(self.AzParseState.IN_SCREENING) and tag == 'time' and len(attrs) > 0:
+        elif self.stateStack.state_is(self.AzParseState.IN_SCREENING) and tag == 'time' and attrs:
             if attrs[0][0] == 'datetime':
                 self.start_dt = datetime.datetime.fromisoformat(attrs[0][1])
         elif self.stateStack.state_is(self.AzParseState.IN_SCREENING) and tag == 'section':
             self.stateStack.push(self.AzParseState.IN_SECTION)
-        elif self.stateStack.state_is(self.AzParseState.IN_SECTION) and tag == 'div' and len(attrs):
+        elif self.stateStack.state_is(self.AzParseState.IN_SECTION) and tag == 'div' and attrs:
             if attrs[0][1].startswith('background-color'):
                 self.section_color = attrs[0][1].split(':')[1]
-        elif self.stateStack.state_is(self.AzParseState.IN_SCREENING) and tag == 'div' and len(attrs) > 0:
+        elif self.stateStack.state_is(self.AzParseState.IN_SCREENING) and tag == 'div' and attrs:
             if attrs[0][1] == 'type':
                 self.stateStack.push(self.AzParseState.IN_TYPE)
         elif self.stateStack.state_is(self.AzParseState.IN_SCREENING) and tag == 'h2':
             self.stateStack.push(self.AzParseState.IN_TITLE)
-        elif self.stateStack.state_is(self.AzParseState.IN_SCREENING) and tag == 'i' and len(attrs) > 0:
+        elif self.stateStack.state_is(self.AzParseState.IN_SCREENING) and tag == 'i' and attrs:
             if attrs[0][1] == 'fa fa-map-marker':
                 self.stateStack.push(self.AzParseState.IN_SCREEN)
             elif attrs[0][1] == 'fa fa-clock-o':
@@ -277,8 +279,9 @@ class AzPageParser(HtmlPageParser):
         HtmlPageParser.handle_data(self, data)
 
         if self.stateStack.state_is(self.AzParseState.IN_SECTION):
-            self.section_name = data
-            self.stateStack.pop()
+            if data.strip():
+                self.section_name = data
+                self.stateStack.pop()
         if self.stateStack.state_is(self.AzParseState.IN_TYPE):
             self.medium_type = data
             self.stateStack.pop()
@@ -299,12 +302,16 @@ class AzPageParser(HtmlPageParser):
 class FilmPageParser(HtmlPageParser):
     class FilmInfoParseState(Enum):
         IDLE = auto()
+        AWAITING_SCREENINGS = auto()
+        IN_SCREENINGS = auto()
+        IN_SCREENING = auto()
+        IN_TIME = auto()
+        IN_SCREEN = auto()
+        AWAITING_TICKET_LINK = auto()
+        IN_TICKETS_LINK = auto()
         AWAITING_DESCRIPTION = auto()
         IN_DESCRIPTION = auto()
         IN_ARTICLE = auto()
-        AWAITING_ALT_DESCRIPTION = auto()
-        IN_ALT_DESCRIPTION = auto()
-        AWAITING_ALT_ARTICLE = auto()
         IN_ALT_ARTICLE = auto()
         AWAITING_METADATA = auto()
         IN_METADATA = auto()
@@ -312,12 +319,16 @@ class FilmPageParser(HtmlPageParser):
         IN_METADATA_VALUE = auto()
         DONE = auto()
 
+    nl_month_by_name = {'okt': 10, 'nov': 11}
+
     def __init__(self, festival_data, film):
-        HtmlPageParser.__init__(self, festival_data, debug_recorder, "F", debugging=True)
+        HtmlPageParser.__init__(self, festival_data, DEBUG_RECORDER, "F", debugging=True)
         self.film = film
+        self.screening_start_date = None
+        self.screening_start_time = None
+        self.screening_screen = None
+        self.screening_ticket_label = None
         self.description = None
-        self.alt_description = None
-        self.alt_description_parts = []
         self.film_property_by_label = {}
         self.metadata_key = None
         self.screened_films = []
@@ -325,17 +336,19 @@ class FilmPageParser(HtmlPageParser):
         self.stateStack = self.StateStack(self.print_debug, self.FilmInfoParseState.IDLE)
         self.print_debug(f"{40 * '-'} ", f"Analysing FILM {film}, {film.url}")
 
-    def set_alt_description(self):
-        parts_count = len(self.alt_description_parts)
-        if parts_count > 1:
-            pluralizer = 's' if parts_count > 2 else ''
-            header = f'Program with {parts_count - 1} part{pluralizer}, total {self.alt_description_parts[0]}'
-            parts = '\n'.join(self.alt_description_parts[1:])
-            self.alt_description = f'{header}\n{parts}'
-        elif parts_count == 1:
-            self.alt_description = self.alt_description_parts[0]
-        else:
-            self.alt_description = None
+    def add_q_and_a_record(self):
+        if 'Q&A' in self.screening_ticket_label:
+            dom, month_str = self.screening_start_date.split('-')   # 27-okt
+            month = self.nl_month_by_name[month_str]
+            hour, minute = self.screening_start_time.split(':')     # 13:30
+            start_dt = datetime.datetime(FESTIVAL_YEAR, month, int(dom), int(hour), int(minute))
+            screen = self.get_imagine_screen()
+            QaScreeningKey(self.film, start_dt, screen).add()
+
+    def get_imagine_screen(self):
+        screen_parse_name = self.screening_screen.strip()
+        splitter = LocationSplitter.split_location
+        return get_screen_from_parse_name(self.festival_data, screen_parse_name, splitter)
 
     def add_paragraph(self):
         paragraph = self.article_paragraph
@@ -345,16 +358,13 @@ class FilmPageParser(HtmlPageParser):
 
     def set_article(self):
         descr_threshold = 512
-        article = '\n\n'.join(self.article_paragraphs)
-        if self.alt_description is None:
-            self.article = article
-        elif len(self.article_paragraphs) > 0:
+        if self.article_paragraphs:
             self.description = self.article_paragraphs[0]
             if len(self.description) > descr_threshold:
                 self.description = self.description[:descr_threshold] + '…'
-            self.article = f'{self.alt_description}\n\n{article}'
+            self.article = '\n\n'.join(self.article_paragraphs)
         else:
-            self.description = self.film.title
+            self.description = ''
             self.article = ''
         if len(self.film_property_by_label):
             properties = [f'{key}: {value}' for (key, value) in self.film_property_by_label.items()]
@@ -362,39 +372,48 @@ class FilmPageParser(HtmlPageParser):
             self.article += f'\n\n{metadata}'
 
     def add_film_info(self):
-        if len(self.description) == 0:
-            self.description = self.film.title
-        film_info = FilmInfo(self.film.film_id, self.description, self.article)
-        self.festival_data.filminfos.append(film_info)
+        if self.description and self.article:
+            film_info = FilmInfo(self.film.film_id, self.description, self.article,
+                                 metadata=self.film_property_by_label)
+            self.festival_data.filminfos.append(film_info)
 
     def finish_film_info(self):
         self.set_article()
         self.add_film_info()
 
-    def in_article(self):
+    def in_any_article(self):
         return self.stateStack.state_in([self.FilmInfoParseState.IN_ARTICLE,
                                          self.FilmInfoParseState.IN_ALT_ARTICLE])
 
     def handle_starttag(self, tag, attrs):
         HtmlPageParser.handle_starttag(self, tag, attrs)
 
-        if self.stateStack.state_is(self.FilmInfoParseState.IDLE) and tag == 'div' and len(attrs) > 0:
+        if self.stateStack.state_is(self.FilmInfoParseState.IDLE) and tag == 'h2':
+            self.stateStack.push(self.FilmInfoParseState.AWAITING_SCREENINGS)
+        elif self.stateStack.state_is(self.FilmInfoParseState.IN_SCREENINGS) and tag == 'tr':
+            self.screening_start_date = attrs[1][1]
+            self.stateStack.push(self.FilmInfoParseState.IN_SCREENING)
+        elif self.stateStack.state_is(self.FilmInfoParseState.IN_SCREENING) and tag == 'td' and attrs:
+            match attrs[0][1]:
+                case 'time':
+                    self.stateStack.push(self.FilmInfoParseState.IN_TIME)
+                case 'theatre':
+                    self.stateStack.push(self.FilmInfoParseState.IN_SCREEN)
+                case 'ticket':
+                    self.stateStack.push(self.FilmInfoParseState.AWAITING_TICKET_LINK)
+        elif self.stateStack.state_is(self.FilmInfoParseState.AWAITING_TICKET_LINK) and tag == 'a':
+            self.stateStack.change(self.FilmInfoParseState.IN_TICKETS_LINK)
+        elif self.stateStack.state_is(self.FilmInfoParseState.IDLE) and tag == 'div' and attrs:
             if attrs[0] == ('class', 'container-wrap'):
                 self.stateStack.push(self.FilmInfoParseState.AWAITING_DESCRIPTION)
         if self.stateStack.state_is(self.FilmInfoParseState.AWAITING_DESCRIPTION) and tag == 'div':
-            if len(attrs) > 0:
+            if attrs:
                 if attrs[0] == ('class', 'text'):
                     self.stateStack.change(self.FilmInfoParseState.IN_DESCRIPTION)
-                elif attrs[0] == ('class', 'w3'):
-                    self.stateStack.change(self.FilmInfoParseState.AWAITING_ALT_DESCRIPTION)
-        elif self.stateStack.state_is(self.FilmInfoParseState.AWAITING_ALT_DESCRIPTION) and tag == 'div':
-            if len(attrs) > 0 and attrs[0] == ('class', 'meta'):
-                self.stateStack.change(self.FilmInfoParseState.IN_ALT_DESCRIPTION)
-        elif self.stateStack.state_is(self.FilmInfoParseState.AWAITING_ALT_ARTICLE) and tag == 'div':
-            if len(attrs) > 0 and attrs[0] == ('class', 'w6'):
-                self.stateStack.change(self.FilmInfoParseState.IN_ALT_ARTICLE)
+                elif attrs[0] == ('class', 'w6'):
+                    self.stateStack.change(self.FilmInfoParseState.IN_ALT_ARTICLE)
         elif self.stateStack.state_is(self.FilmInfoParseState.AWAITING_METADATA) and tag == 'div':
-            if len(attrs) > 0 and attrs[0] == ('class', 'meta'):
+            if attrs and attrs[0] == ('class', 'meta'):
                 self.stateStack.change(self.FilmInfoParseState.IN_METADATA)
         elif self.stateStack.state_is(self.FilmInfoParseState.IN_METADATA) and tag == 'div':
             self.stateStack.push(self.FilmInfoParseState.IN_METADATA_KEY)
@@ -402,10 +421,13 @@ class FilmPageParser(HtmlPageParser):
     def handle_endtag(self, tag):
         HtmlPageParser.handle_endtag(self, tag)
 
-        if self.stateStack.state_is(self.FilmInfoParseState.IN_ALT_DESCRIPTION) and tag == 'div':
-            self.set_alt_description()
-            self.stateStack.change(self.FilmInfoParseState.AWAITING_ALT_ARTICLE)
-        elif self.in_article() and tag == 'p':
+        if self.stateStack.state_is(self.FilmInfoParseState.AWAITING_SCREENINGS) and tag == 'h2':
+            self.stateStack.pop()
+        elif self.stateStack.state_is(self.FilmInfoParseState.IN_SCREENING) and tag == 'tr':
+            self.stateStack.pop()
+        elif self.stateStack.state_is(self.FilmInfoParseState.IN_SCREENINGS) and tag == 'table':
+            self.stateStack.pop()
+        elif self.in_any_article() and tag == 'p':
             self.add_paragraph()
         elif self.stateStack.state_is(self.FilmInfoParseState.IN_ARTICLE) and tag == 'div':
             self.stateStack.change(self.FilmInfoParseState.AWAITING_METADATA)
@@ -423,16 +445,25 @@ class FilmPageParser(HtmlPageParser):
     def handle_data(self, data):
         HtmlPageParser.handle_data(self, data)
 
-        if self.stateStack.state_is(self.FilmInfoParseState.IN_DESCRIPTION):
+        if self.stateStack.state_is(self.FilmInfoParseState.AWAITING_SCREENINGS):
+            if data == 'Screenings & Tickets':
+                self.stateStack.change(self.FilmInfoParseState.IN_SCREENINGS)
+        elif self.stateStack.state_is(self.FilmInfoParseState.IN_TIME):
+            self.screening_start_time = data
+            self.stateStack.pop()
+        elif self.stateStack.state_is(self.FilmInfoParseState.IN_SCREEN):
+            self.screening_screen = data
+            self.stateStack.pop()
+        elif self.stateStack.state_is(self.FilmInfoParseState.IN_TICKETS_LINK):
+            self.screening_ticket_label = data
+            self.add_q_and_a_record()
+            self.stateStack.pop()
+        elif self.stateStack.state_is(self.FilmInfoParseState.IN_DESCRIPTION):
             if len(data.strip()) > 0:
                 self.description = data
                 self.stateStack.change(self.FilmInfoParseState.IN_ARTICLE)
-        elif self.in_article():
+        elif self.in_any_article():
             self.article_paragraph += data
-        elif self.stateStack.state_is(self.FilmInfoParseState.IN_ALT_DESCRIPTION):
-            part = data.strip()
-            if len(part):
-                self.alt_description_parts.append(part)
         elif self.stateStack.state_is(self.FilmInfoParseState.IN_METADATA_KEY):
             self.metadata_key = data.strip()
             self.stateStack.change(self.FilmInfoParseState.IN_METADATA_VALUE)
@@ -440,10 +471,71 @@ class FilmPageParser(HtmlPageParser):
             self.film_property_by_label[self.metadata_key] = data.strip()
 
 
-class ImagineData(FestivalData):
+class LocationSplitter:
+    num_screen_re = re.compile(r'^(?P<theater>.*?) (?P<number>\d+)$')
 
-    def _init__(self, plandata_dir):
-        super().__init__(festival_city, plandata_dir)
+    @classmethod
+    def split_location(cls, location):
+        city_name = FESTIVAL_CITY
+        theater_parse_name = location
+        default_screen_abbreviation = 'zaal'
+        num_match = cls.num_screen_re.match(location)
+        if location.startswith('KINO'):
+            city_name = 'Rotterdam'
+        if location == 'SPUI 25':
+            theater_parse_name = location
+            screen_abbreviation = default_screen_abbreviation
+        elif location == 'OBA Oosterdok OBA Theater':
+            location_words = location.split()
+            theater_parse_name = ' '.join(location_words[:2])
+            screen_abbreviation = ' '.join(location_words[2:])
+        elif num_match:
+            theater_parse_name = num_match.group(1)
+            screen_abbreviation = num_match.group(2)
+        elif location.startswith('LAB111 '):
+            theater_parse_name = 'LAB111'
+            screen_abbreviation = location.split()[1]
+        else:
+            screen_abbreviation = default_screen_abbreviation
+        return city_name, theater_parse_name, screen_abbreviation
+
+
+class QaScreeningKey:
+    manual_keys = {
+        (21, 118, datetime.datetime.fromisoformat('2024-10-25 16:40:00')),
+        (44, 51, datetime.datetime.fromisoformat('2024-10-26 21:40:00')),
+        (50, 118, datetime.datetime.fromisoformat('2024-10-27 13:45:00')),
+        (56, 52, datetime.datetime.fromisoformat('2024-10-27 16:30:00')),
+        (59, 51, datetime.datetime.fromisoformat('2024-11-01 18:30:00')),
+    }
+
+    def __init__(self, film, start_dt, screen):
+        self.film = film
+        self.start_dt = start_dt
+        self.screen = screen
+
+    def __str__(self):
+        return (f'film id: {self.film.film_id} - {self.start_dt.isoformat(sep=" ")} '
+                f'- screen id: {self.screen.screen_id}')
+
+    def add(self):
+        Q_AND_A_SCREENING_KEYS.append(self)
+
+    @classmethod
+    def update_q_and_a_screenings(cls, festival_data):
+        auto_keys = {(k.film.film_id, k.screen.screen_id, k.start_dt) for k in Q_AND_A_SCREENING_KEYS}
+        rhs_list = auto_keys | cls.manual_keys
+        for screening in festival_data.screenings:
+            lhs = (screening.film.film_id, screening.screen.screen_id, screening.start_datetime)
+            for rhs in rhs_list:
+                if rhs == lhs:
+                    screening.q_and_a = 'Q&A'
+                    COUNTER.increase('q&a screenings')
+
+
+class ImagineData(FestivalData):
+    def __init__(self, plandata_dir):
+        super().__init__(FESTIVAL_CITY, plandata_dir)
 
     def film_key(self, film, url):
         return url

--- a/FilmFestivalLoader/NFF/parse_nff_html.py
+++ b/FilmFestivalLoader/NFF/parse_nff_html.py
@@ -39,7 +39,7 @@ film_file_format = file_keeper.film_file_format
 
 # Files.
 filmdata_file = os.path.join(plandata_dir, 'filmdata.csv')
-filminfo_file = os.path.join(plandata_dir, 'filminfo.xml')
+filminfo_xml_file = os.path.join(plandata_dir, 'filminfo.xml')
 az_screenshot_file = os.path.join(webdata_dir, 'az-screencopies.txt')
 
 # URL information.

--- a/Tools/compare_planner_data.sh
+++ b/Tools/compare_planner_data.sh
@@ -7,6 +7,7 @@ declare -r files="
     screenings.csv
     sections.csv
     subsections.csv
+    filminfo.csv
     filminfo.xml
     filminfo.yml
 "


### PR DESCRIPTION
* views.py: Add a choice to availability choices.

* compare_planner_data.sh:
* models.py:
* parse_nff_html.py: Use .csv for cvs files, .xml for xml and .yml for yaml.

* project_style.css: Minor simplification.

* models.py: Implement questionability of the highest rating being representative.

* views.py: Use .csv for cvs files, .xml for xml and .yml for yaml. Only display selected fans in details views.
Display metadata in film details view.

* models.py: Combine representive rating symbol with fitting color based on background and interestingness.

* views.py: Combine representive rating symbol with fitting color based on background and interestingness.
Display a screening's program section color.
Only display selected fans in details views.

* list.html: Slight reformatting. Allow only admin fans.

* details.html: Display metadata in film details view.

* ratings.html: Add a shortcut link.

* day_schema.html: Neater and more consequent layout. Display a screening's program section color.

* parse_imagine_html.py: Global constants in capitals. Support Imagine 2024.
Finf Q&A screening property.

* planner_interface.py: Use .csv for cvs files, .xml for xml and .yml for yaml.
Display metadata in film details view.